### PR TITLE
Add dentist scheduling workflow with confirmations and voice assistant

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,104 +1,244 @@
-import React, { useState } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { Calendar, ChevronLeft, ChevronRight, Clock, MapPin, UserRound } from 'lucide-react';
 
-interface Slot {
-  id: string;
-  time: string;
-  patient: string | null;
-  doctor: string;
-  procedure: string;
-}
+import { appointmentStatusMeta } from '../constants/appointmentStatus';
+import { useSchedule } from '../context/ScheduleContext';
+import type { Appointment } from '../data/schedule';
+import { addMinutesToTime, formatDateHuman, formatDateKey } from '../utils/date';
 
-const rooms = ['Кабинет 1', 'Кабинет 2', 'Кабинет 3'];
-
-const generateSlots = (date: Date) => {
-  const slots: Record<string, Slot[]> = {};
-  rooms.forEach(room => {
-    slots[room] = [
-      { id: `${room}-09`, time: '09:00', patient: Math.random() > 0.6 ? 'Иванов И.И.' : null, doctor: 'Докт. Смирнов', procedure: 'Осмотр' },
-      { id: `${room}-0930`, time: '09:30', patient: Math.random() > 0.6 ? 'Петрова А.В.' : null, doctor: 'Асс. Петрова', procedure: 'Гигиена' },
-      { id: `${room}-10`, time: '10:00', patient: Math.random() > 0.6 ? 'Сидоров П.П.' : null, doctor: 'Докт. Лебедева', procedure: 'Пломбирование' },
-    ];
-  });
-  return slots;
-};
+const weekdayLabels = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'];
 
 export default function CalendarView() {
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const { appointments, rooms, doctors } = useSchedule();
+  const today = useMemo(() => new Date(), []);
+  const [viewDate, setViewDate] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1));
+  const [selectedDate, setSelectedDate] = useState(() => formatDateKey(today));
 
-  const slots = generateSlots(selectedDate);
+  const monthKey = `${viewDate.getFullYear()}-${viewDate.getMonth()}`;
 
-  const year = selectedDate.getFullYear();
-  const month = selectedDate.getMonth();
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  const firstDay = (new Date(year, month, 1).getDay() + 6) % 7;
+  const appointmentsByDate = useMemo(() => {
+    const grouped = new Map<string, Appointment[]>();
+    appointments.forEach((appointment) => {
+      const date = appointment.date;
+      const existing = grouped.get(date) ?? [];
+      existing.push(appointment);
+      grouped.set(date, existing);
+    });
+    grouped.forEach((list) => list.sort((a, b) => a.time.localeCompare(b.time)));
+    return grouped;
+  }, [appointments]);
 
-  const shiftMonth = (dir: number) => {
-    const d = new Date(selectedDate);
-    d.setMonth(d.getMonth() + dir);
-    setSelectedDate(d);
+  const daysInMonth = new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 0).getDate();
+  const firstWeekday = (new Date(viewDate.getFullYear(), viewDate.getMonth(), 1).getDay() + 6) % 7;
+  const totalCells = Math.ceil((firstWeekday + daysInMonth) / 7) * 7;
+  const cells = Array.from({ length: totalCells }).map((_, index) => {
+    const dayOffset = index - firstWeekday;
+    const cellDate = new Date(viewDate.getFullYear(), viewDate.getMonth(), dayOffset + 1);
+    const key = formatDateKey(cellDate);
+    const inCurrentMonth = cellDate.getMonth() === viewDate.getMonth();
+    const dayAppointments = appointmentsByDate.get(key) ?? [];
+    const requiresAttention = dayAppointments.some(
+      (appointment) => appointment.status === 'needs-confirmation' || appointment.status === 'needs-follow-up',
+    );
+    const confirmedCount = dayAppointments.filter((appointment) => appointment.status === 'confirmed').length;
+    return {
+      date: cellDate,
+      key,
+      inCurrentMonth,
+      appointments: dayAppointments,
+      requiresAttention,
+      confirmedCount,
+    };
+  });
+
+  const selectedAppointments = appointmentsByDate.get(selectedDate) ?? [];
+  const appointmentsByRoom = useMemo(() => {
+    const grouped = new Map<string, Appointment[]>();
+    rooms.forEach((room) => grouped.set(room, []));
+    selectedAppointments.forEach((appointment) => {
+      const room = grouped.get(appointment.room);
+      if (room) {
+        room.push(appointment);
+      } else {
+        grouped.set(appointment.room, [appointment]);
+      }
+    });
+    grouped.forEach((list) => list.sort((a, b) => a.time.localeCompare(b.time)));
+    return grouped;
+  }, [rooms, selectedAppointments]);
+
+  const shiftMonth = (offset: number) => {
+    setViewDate((prev) => {
+      const next = new Date(prev);
+      next.setMonth(prev.getMonth() + offset);
+      return next;
+    });
   };
 
+  const selectToday = () => {
+    setViewDate(new Date(today.getFullYear(), today.getMonth(), 1));
+    setSelectedDate(formatDateKey(today));
+  };
+
+  const doctorMap = useMemo(() => new Map(doctors.map((doctor) => [doctor.id, doctor])), [doctors]);
+
   return (
-    <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
-      {/* календарь */}
-      <div className="bg-card border border-page rounded-xl shadow-lg p-4">
-        <div className="flex items-center justify-between mb-4">
-          <button onClick={() => shiftMonth(-1)} className="p-2 rounded-full bg-card"><ChevronLeft /></button>
-          <h3 className="text-lg font-bold">{selectedDate.toLocaleDateString('ru-RU', { month: 'long', year: 'numeric' })}</h3>
-          <button onClick={() => shiftMonth(1)} className="p-2 rounded-full bg-card"><ChevronRight /></button>
-        </div>
-
-        <div className="grid grid-cols-7 gap-1 text-center text-sm">
-          {['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'].map(d => (
-            <div key={d} className="font-medium text-page/70">{d}</div>
-          ))}
-          {Array.from({ length: firstDay }).map((_, i) => <div key={i} />)}
-          {Array.from({ length: daysInMonth }, (_, i) => i + 1).map(d => {
-            const date = new Date(year, month, d);
-            const isSelected = date.toDateString() === selectedDate.toDateString();
-            const isToday = date.toDateString() === new Date().toDateString();
-            return (
-              <button
-                key={d}
-                onClick={() => setSelectedDate(date)}
-                className={`p-2 rounded-lg transition-all ${isSelected ? 'bg-orange-500 text-white' : isToday ? 'bg-orange-200 text-orange-800' : 'hover:bg-orange-100'}`}
-              >
-                {d}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* 3 столбца кабинетов */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {['Кабинет 1', 'Кабинет 2', 'Кабинет 3'].map(room => (
-          <div key={room} className="bg-card border border-page rounded-xl shadow-lg p-4">
-            <h3 className="text-lg font-semibold mb-3 text-center">{room}</h3>
-            <div className="space-y-2">
-              {(['09:00', '09:30', '10:00'] as const).map(time => {
-                const slot = (generateSlots(selectedDate)[room] || []).find(s => s.time === time);
-                return (
-                  <div
-                    key={`${room}-${time}`}
-                    className="flex items-center justify-between p-2 rounded-lg hover:bg-orange-50 transition-colors"
-                  >
-                    <span className="font-medium text-sm">{time}</span>
-                    <span className="text-xs text-page/80">{slot?.doctor ?? ''}</span>
-                    <span
-                      className="text-sm truncate cursor-help"
-                      title={slot?.procedure ?? ''}
-                    >
-                      {slot?.patient ?? <span className="italic text-page/60">Свободно</span>}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
+    <section className="space-y-6">
+      <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Месячный обзор</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-300">
+              {formatDateHuman(formatDateKey(viewDate), { month: 'long', year: 'numeric' })}
+            </p>
           </div>
-        ))}
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => shiftMonth(-1)}
+              className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-orange-200 hover:text-orange-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Предыдущий месяц
+            </button>
+            <button
+              type="button"
+              onClick={selectToday}
+              className="inline-flex items-center gap-2 rounded-2xl border border-orange-200 bg-orange-50 px-3 py-2 text-sm font-semibold text-orange-700 transition hover:border-orange-300 hover:bg-orange-100 dark:border-orange-500/40 dark:bg-orange-500/20 dark:text-orange-100"
+            >
+              <Calendar className="h-4 w-4" />
+              Сегодня
+            </button>
+            <button
+              type="button"
+              onClick={() => shiftMonth(1)}
+              className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-orange-200 hover:text-orange-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+            >
+              Следующий месяц
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-6 overflow-hidden rounded-3xl border border-slate-200 dark:border-slate-700">
+          <div className="grid grid-cols-7 bg-slate-50 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900/80 dark:text-slate-400">
+            {weekdayLabels.map((label) => (
+              <span key={label}>{label}</span>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 border-t border-slate-200 text-sm dark:border-slate-700">
+            {cells.map((cell) => {
+              const isSelected = cell.key === selectedDate;
+              const isToday = cell.key === formatDateKey(today);
+              return (
+                <button
+                  key={`${monthKey}-${cell.key}`}
+                  type="button"
+                  onClick={() => setSelectedDate(cell.key)}
+                  className={`relative min-h-[92px] border-b border-r border-slate-200 p-3 text-left transition hover:bg-orange-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 dark:border-slate-700 dark:hover:bg-orange-500/10 ${
+                    cell.inCurrentMonth ? 'bg-white dark:bg-slate-900' : 'bg-slate-50 text-slate-400 dark:bg-slate-900/60 dark:text-slate-600'
+                  } ${isSelected ? 'ring-2 ring-orange-400 ring-offset-2 ring-offset-white dark:ring-offset-slate-900' : ''}`}
+                >
+                  <span className={`inline-flex h-7 w-7 items-center justify-center rounded-full text-sm font-semibold ${
+                    isToday
+                      ? 'bg-orange-500 text-white shadow'
+                      : 'text-slate-600 dark:text-slate-300'
+                  }`}>
+                    {cell.date.getDate()}
+                  </span>
+                  {cell.appointments.length > 0 ? (
+                    <div className="mt-2 space-y-1">
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
+                        {cell.appointments.length} визитов
+                      </p>
+                      {cell.requiresAttention ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-500/20 dark:text-amber-100">
+                          Требует подтверждения
+                        </span>
+                      ) : null}
+                      {cell.confirmedCount > 0 ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-100">
+                          Подтверждено: {cell.confirmedCount}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
-    </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+              {formatDateHuman(selectedDate, { day: 'numeric', month: 'long', year: 'numeric' })}
+            </h3>
+            <p className="text-sm text-slate-500 dark:text-slate-300">
+              Распределение по кабинетам и статусам
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from(appointmentsByRoom.entries()).map(([room, list]) => (
+            <div
+              key={room}
+              className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70"
+            >
+              <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">{room}</h4>
+              {list.length > 0 ? (
+                <ul className="mt-3 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+                  {list.map((appointment) => {
+                    const doctor = doctorMap.get(appointment.doctorId);
+                    return (
+                      <li
+                        key={appointment.id}
+                        className="rounded-2xl border border-slate-200 bg-white px-3 py-3 shadow-inner transition hover:border-orange-200 hover:shadow-md dark:border-slate-700 dark:bg-slate-900"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500 dark:text-slate-400">
+                          <span className="inline-flex items-center gap-1 text-slate-600 dark:text-slate-300">
+                            <Clock className="h-3.5 w-3.5" />
+                            {appointment.time}–{addMinutesToTime(appointment.time, appointment.duration)}
+                          </span>
+                          <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold ${appointmentStatusMeta[appointment.status].badgeClassName}`}>
+                            {appointmentStatusMeta[appointment.status].label}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm font-semibold text-slate-900 dark:text-white">
+                          {appointment.patient.name}
+                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                          {doctor ? (
+                            <span className="inline-flex items-center gap-1">
+                              <UserRound className="h-3.5 w-3.5" />
+                              {doctor.name}
+                            </span>
+                          ) : null}
+                          <span className="inline-flex items-center gap-1">
+                            <MapPin className="h-3.5 w-3.5" />
+                            {appointment.room}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                          {appointment.procedure}
+                        </p>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="mt-4 text-sm text-slate-400 dark:text-slate-500">
+                  Нет записей на этот день в кабинете.
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
+

--- a/src/components/DoctorConfirmationPanel.tsx
+++ b/src/components/DoctorConfirmationPanel.tsx
@@ -1,0 +1,330 @@
+import React, { useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CalendarCheck,
+  CheckCircle2,
+  Clock,
+  MessageSquareText,
+  RefreshCcw,
+  ShieldCheck,
+  UserCheck,
+} from 'lucide-react';
+
+import { appointmentStatusMeta } from '../constants/appointmentStatus';
+import { useSchedule } from '../context/ScheduleContext';
+import type { Appointment, AppointmentStatus } from '../data/schedule';
+import { tomorrowKey } from '../data/schedule';
+import { addMinutesToTime, formatDateHuman, formatWeekday } from '../utils/date';
+
+const statusStyles = {
+  pending: {
+    label: 'Ожидает ответа',
+    className:
+      'border border-dashed border-slate-300 bg-slate-50 text-slate-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300',
+    icon: <Clock className="h-4 w-4" />,
+  },
+  confirmed: {
+    label: 'Подтверждено',
+    className:
+      'border border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/20 dark:text-emerald-100',
+    icon: <CheckCircle2 className="h-4 w-4" />,
+  },
+  'needs-changes': {
+    label: 'Требует изменений',
+    className:
+      'border border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100',
+    icon: <AlertTriangle className="h-4 w-4" />,
+  },
+} as const;
+
+type DoctorStatus = keyof typeof statusStyles;
+
+const formatWeekdayLabel = (value: string) => {
+  const raw = formatWeekday(value);
+  return raw.charAt(0).toUpperCase() + raw.slice(1);
+};
+
+export default function DoctorConfirmationPanel() {
+  const { appointments, doctors, doctorConfirmations, confirmDoctorDay } = useSchedule();
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+
+  const tomorrowLabel = formatDateHuman(tomorrowKey, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+  const weekdayLabel = formatWeekdayLabel(tomorrowKey);
+
+  const confirmationMap = useMemo(() => {
+    const map = new Map<string, DoctorStatus>();
+    doctorConfirmations
+      .filter((item) => item.date === tomorrowKey)
+      .forEach((item) => {
+        map.set(item.doctorId, item.status);
+      });
+    return map;
+  }, [doctorConfirmations]);
+
+  const noteMap = useMemo(() => {
+    const map = new Map<string, string | undefined>();
+    doctorConfirmations
+      .filter((item) => item.date === tomorrowKey)
+      .forEach((item) => {
+        map.set(item.doctorId, item.note);
+      });
+    return map;
+  }, [doctorConfirmations]);
+
+  const doctorAppointments = useMemo(() => {
+    const grouped = new Map<string, GroupedAppointments>();
+    doctors.forEach((doctor) => {
+      grouped.set(doctor.id, buildGroupedAppointments(appointments, doctor.id, tomorrowKey));
+    });
+    return grouped;
+  }, [appointments, doctors]);
+
+  const totals = useMemo(() => {
+    const summary = {
+      confirmed: 0,
+      pending: 0,
+      needsChanges: 0,
+      totalVisits: 0,
+    };
+    doctors.forEach((doctor) => {
+      const status = confirmationMap.get(doctor.id) ?? 'pending';
+      if (status === 'confirmed') summary.confirmed += 1;
+      if (status === 'pending') summary.pending += 1;
+      if (status === 'needs-changes') summary.needsChanges += 1;
+      const grouped = doctorAppointments.get(doctor.id);
+      summary.totalVisits += grouped?.total ?? 0;
+    });
+    return summary;
+  }, [confirmationMap, doctorAppointments, doctors]);
+
+  const handleConfirm = (doctorId: string) => {
+    confirmDoctorDay(doctorId, tomorrowKey, 'confirmed', notes[doctorId]);
+    setErrors((prev) => ({ ...prev, [doctorId]: undefined }));
+  };
+
+  const handleNeedsChanges = (doctorId: string) => {
+    if (!notes[doctorId]?.trim()) {
+      setErrors((prev) => ({ ...prev, [doctorId]: 'Опишите, что нужно изменить в расписании.' }));
+      return;
+    }
+    confirmDoctorDay(doctorId, tomorrowKey, 'needs-changes', notes[doctorId]);
+    setErrors((prev) => ({ ...prev, [doctorId]: undefined }));
+  };
+
+  const handleReset = (doctorId: string) => {
+    confirmDoctorDay(doctorId, tomorrowKey, 'pending', notes[doctorId]);
+  };
+
+  return (
+    <section className="space-y-6">
+      <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+              Подтверждение расписания докторов
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-300">
+              На {tomorrowLabel} · {weekdayLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <StatusBadge icon={<ShieldCheck className="h-4 w-4" />} colorClass="bg-emerald-500/10 text-emerald-700 dark:text-emerald-100">
+              Подтвердили: {totals.confirmed} / {doctors.length}
+            </StatusBadge>
+            <StatusBadge icon={<Clock className="h-4 w-4" />} colorClass="bg-slate-100 text-slate-600 dark:bg-slate-900/60 dark:text-slate-300">
+              Ожидают: {totals.pending}
+            </StatusBadge>
+            <StatusBadge icon={<AlertTriangle className="h-4 w-4" />} colorClass="bg-amber-50 text-amber-700 dark:bg-amber-500/20 dark:text-amber-100">
+              Нужна реакция: {totals.needsChanges}
+            </StatusBadge>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {doctors.map((doctor) => {
+          const status = confirmationMap.get(doctor.id) ?? 'pending';
+          const schedule = doctorAppointments.get(doctor.id) ?? emptyGroup;
+          const noteValue = notes[doctor.id] ?? noteMap.get(doctor.id) ?? '';
+
+          return (
+            <article
+              key={doctor.id}
+              className="flex h-full flex-col gap-4 rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-orange-200 hover:shadow-md dark:border-slate-700 dark:bg-slate-900/60"
+            >
+              <header className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">{doctor.name}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{doctor.speciality}</p>
+                </div>
+                <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${statusStyles[status].className}`}>
+                  {statusStyles[status].icon}
+                  {statusStyles[status].label}
+                </span>
+              </header>
+
+              <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm shadow-inner dark:border-slate-700 dark:bg-slate-900/80">
+                <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                  <span className="inline-flex items-center gap-1">
+                    <CalendarCheck className="h-3.5 w-3.5" />
+                    {schedule.total} приём(а)
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <UserCheck className="h-3.5 w-3.5" />
+                    {schedule.needsConfirmation} ждут подтверждения
+                  </span>
+                </div>
+                <ul className="mt-3 space-y-2 text-xs text-slate-500 dark:text-slate-400">
+                  {schedule.slots.length > 0 ? (
+                    schedule.slots.map((slot) => (
+                      <li key={slot.id} className="flex items-start justify-between gap-2 rounded-xl bg-white/80 px-3 py-2 shadow-sm dark:bg-slate-900/60">
+                        <span className="font-medium text-slate-700 dark:text-slate-200">
+                          {slot.time}–{addMinutesToTime(slot.time, slot.duration)}
+                        </span>
+                        <span className="flex-1 truncate text-right text-slate-500 dark:text-slate-400">
+                          {slot.patient}
+                        </span>
+                        <span className={`ml-2 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 ${appointmentStatusMeta[slot.status].badgeClassName}`}>
+                          <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                          {appointmentStatusMeta[slot.status].label}
+                        </span>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="rounded-xl border border-dashed border-slate-300 px-3 py-4 text-center text-slate-400 dark:border-slate-700 dark:text-slate-500">
+                      Нет приёмов на завтра.
+                    </li>
+                  )}
+                </ul>
+              </div>
+
+              <div className="space-y-2 text-xs text-slate-500 dark:text-slate-400">
+                <label className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                  <MessageSquareText className="h-3.5 w-3.5" />
+                  Комментарий доктора
+                </label>
+                <textarea
+                  value={noteValue}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setNotes((prev) => ({ ...prev, [doctor.id]: value }));
+                    if (value.trim().length > 0) {
+                      setErrors((prev) => ({ ...prev, [doctor.id]: undefined }));
+                    }
+                  }}
+                  onBlur={() => {
+                    const stored = noteMap.get(doctor.id) ?? '';
+                    if (noteValue !== stored) {
+                      confirmDoctorDay(doctor.id, tomorrowKey, status, noteValue);
+                    }
+                  }}
+                  rows={3}
+                  placeholder="Например: прошу сдвинуть имплантацию на 30 минут"
+                  className="w-full resize-none rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600 shadow-sm transition focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+                />
+                {errors[doctor.id] ? (
+                  <p className="text-xs text-rose-500">{errors[doctor.id]}</p>
+                ) : null}
+              </div>
+
+              <div className="mt-auto flex flex-wrap items-center gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => handleConfirm(doctor.id)}
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-orange-400 to-amber-400 px-4 py-2 text-sm font-semibold text-white shadow transition hover:from-orange-500 hover:to-amber-500"
+                >
+                  <CheckCircle2 className="h-4 w-4" />
+                  Подтвердить
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleNeedsChanges(doctor.id)}
+                  className="inline-flex items-center gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 transition hover:border-amber-300 hover:bg-amber-100 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
+                >
+                  <AlertTriangle className="h-4 w-4" />
+                  Нужны правки
+                </button>
+                {status !== 'pending' ? (
+                  <button
+                    type="button"
+                    onClick={() => handleReset(doctor.id)}
+                    className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-500 transition hover:border-slate-300 hover:text-slate-700 dark:border-slate-600 dark:text-slate-300 dark:hover:border-slate-500"
+                  >
+                    <RefreshCcw className="h-4 w-4" />
+                    Вернуть в ожидание
+                  </button>
+                ) : null}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+interface GroupedAppointments {
+  total: number;
+  needsConfirmation: number;
+  slots: {
+    id: string;
+    time: string;
+    duration: number;
+    patient: string;
+    status: AppointmentStatus;
+  }[];
+}
+
+const emptyGroup: GroupedAppointments = {
+  total: 0,
+  needsConfirmation: 0,
+  slots: [],
+};
+
+const buildGroupedAppointments = (
+  appointments: Appointment[],
+  doctorId: string,
+  date: string,
+): GroupedAppointments => {
+  const slots = appointments
+    .filter((appointment) => appointment.date === date && appointment.doctorId === doctorId)
+    .sort((a, b) => a.time.localeCompare(b.time))
+    .map((appointment) => ({
+      id: appointment.id,
+      time: appointment.time,
+      duration: appointment.duration,
+      patient: appointment.patient.name,
+      status: appointment.status,
+    }));
+
+  return {
+    total: slots.length,
+    needsConfirmation: slots.filter(
+      (slot) => slot.status === 'needs-confirmation' || slot.status === 'needs-follow-up',
+    ).length,
+    slots,
+  };
+};
+
+interface StatusBadgeProps {
+  icon: React.ReactNode;
+  colorClass: string;
+  children: React.ReactNode;
+}
+
+function StatusBadge({ icon, colorClass, children }: StatusBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${colorClass}`}
+    >
+      {icon}
+      {children}
+    </span>
+  );
+}
+

--- a/src/components/ScheduleTable.tsx
+++ b/src/components/ScheduleTable.tsx
@@ -1,138 +1,518 @@
-import React, { useState } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  AlertCircle,
+  CalendarClock,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  ClipboardList,
+  MapPin,
+  Phone,
+  Stethoscope,
+  UserRound,
+} from 'lucide-react';
 
-type Period = 'day' | 'week' | 'month' | '3m' | '6m' | 'year';
+import { appointmentStatusMeta, appointmentStatusSelectOptions } from '../constants/appointmentStatus';
+import { useSchedule } from '../context/ScheduleContext';
+import type { Appointment, AppointmentStatus } from '../data/schedule';
+import {
+  addDays,
+  addMinutesToTime,
+  compareTime,
+  formatDateHuman,
+  formatDateKey,
+  formatWeekday,
+  parseDateKey,
+} from '../utils/date';
 
-interface Slot {
-  id: string;
-  date: string;       // ISO
-  time: string;
-  patient: string | null;
-  doctor: string;
-  procedure: string;
-}
-
-const rooms = ['Кабинет 1', 'Кабинет 2', 'Кабинет 3'];
-
-// генерация мок-данных
-const generateMock = (period: Period, startDate: Date): Slot[] => {
-  const slots: Slot[] = [];
-  let days = 1;
-  if (period === 'week') days = 7;
-  if (period === 'month') days = 30;
-  if (period === '3m') days = 90;
-  if (period === '6m') days = 180;
-  if (period === 'year') days = 365;
-
-  for (let d = 0; d < days; d++) {
-    const date = new Date(startDate);
-    date.setDate(date.getDate() + d);
-
-    rooms.forEach(room => {
-      ['09:00', '09:30', '10:00', '10:30', '11:00'].forEach(time => {
-        slots.push({
-          id: `${date.toISOString()}-${room}-${time}`,
-          date: date.toISOString(),
-          time,
-          patient: Math.random() > 0.6 ? `Пациент ${Math.floor(Math.random() * 100)}` : null,
-          doctor: Math.random() > 0.5 ? 'Докт. Смирнов' : 'Асс. Петрова',
-          procedure: 'Осмотр',
-        });
-      });
-    });
+const getStatusIcon = (status: AppointmentStatus) => {
+  switch (status) {
+    case 'confirmed':
+    case 'completed':
+      return <CheckCircle2 className="h-4 w-4" />;
+    case 'needs-confirmation':
+    case 'needs-follow-up':
+      return <AlertCircle className="h-4 w-4" />;
+    case 'checked-in':
+      return <CalendarClock className="h-4 w-4" />;
+    case 'cancelled':
+      return <AlertCircle className="h-4 w-4" />;
+    default:
+      return <ClipboardList className="h-4 w-4" />;
   }
-  return slots;
 };
 
+const emptyMessage = 'На выбранную дату пока нет записей. Добавьте приём или выберите другой день.';
+
+const createDoctorAvatarStyle = (color: string) => ({
+  background: color,
+  boxShadow: `0 10px 30px ${color}33`,
+});
+
+const toDateInputValue = (value: string) => value;
+
+const nextDate = (value: string, offset: number) => formatDateKey(addDays(parseDateKey(value), offset));
+
+const minutesToLabel = (minutes: number) => `${minutes} мин.`;
+
 export default function ScheduleTable() {
-  const [period, setPeriod] = useState<Period>('day');
-  const [startDate, setStartDate] = useState(new Date());
+  const {
+    appointments,
+    doctors,
+    assistants,
+    updateAppointmentStatus,
+    updateAppointmentNote,
+  } = useSchedule();
 
-  const slots = generateMock(period, startDate);
+  const [selectedDate, setSelectedDate] = useState<string>(() => formatDateKey(new Date()));
+  const [selectedDoctorId, setSelectedDoctorId] = useState<string>('all');
+  const [selectedAppointmentId, setSelectedAppointmentId] = useState<string | null>(null);
+  const [noteDraft, setNoteDraft] = useState<string>('');
 
-  const titles = {
-    day: 'Сегодня',
-    week: 'Неделя',
-    month: 'Месяц',
-    '3m': '3 месяца',
-    '6m': 'Полгода',
-    year: 'Год',
+  const filteredAppointments = useMemo(
+    () =>
+      appointments
+        .filter(
+          (appointment) =>
+            appointment.date === selectedDate &&
+            (selectedDoctorId === 'all' || appointment.doctorId === selectedDoctorId),
+        )
+        .sort((a, b) => compareTime(a.time, b.time)),
+    [appointments, selectedDate, selectedDoctorId],
+  );
+
+  const doctorMap = useMemo(
+    () => new Map(doctors.map((doctor) => [doctor.id, doctor])),
+    [doctors],
+  );
+
+  const assistantMap = useMemo(
+    () => new Map(assistants.map((assistant) => [assistant.id, assistant])),
+    [assistants],
+  );
+
+  const doctorsForDate = useMemo(() => {
+    const doctorIds = new Set(filteredAppointments.map((appointment) => appointment.doctorId));
+    const pool = doctorIds.size > 0 ? doctors.filter((doctor) => doctorIds.has(doctor.id)) : doctors;
+    return selectedDoctorId === 'all'
+      ? pool
+      : pool.filter((doctor) => doctor.id === selectedDoctorId);
+  }, [doctors, filteredAppointments, selectedDoctorId]);
+
+  useEffect(() => {
+    if (!selectedAppointmentId && filteredAppointments.length > 0) {
+      setSelectedAppointmentId(filteredAppointments[0].id);
+      return;
+    }
+    if (selectedAppointmentId && !filteredAppointments.some((appointment) => appointment.id === selectedAppointmentId)) {
+      setSelectedAppointmentId(filteredAppointments[0]?.id ?? null);
+    }
+  }, [filteredAppointments, selectedAppointmentId]);
+
+  const selectedAppointment = filteredAppointments.find(
+    (appointment) => appointment.id === selectedAppointmentId,
+  );
+
+  useEffect(() => {
+    setNoteDraft(selectedAppointment?.note ?? '');
+  }, [selectedAppointment?.id, selectedAppointment?.note]);
+
+  const totals = useMemo(() => {
+    const summary = {
+      total: filteredAppointments.length,
+      confirmed: 0,
+      waiting: 0,
+      followUp: 0,
+      cancelled: 0,
+    };
+    filteredAppointments.forEach((appointment) => {
+      switch (appointment.status) {
+        case 'confirmed':
+        case 'checked-in':
+        case 'completed':
+          summary.confirmed += 1;
+          break;
+        case 'needs-confirmation':
+        case 'scheduled':
+          summary.waiting += 1;
+          break;
+        case 'needs-follow-up':
+          summary.followUp += 1;
+          break;
+        case 'cancelled':
+          summary.cancelled += 1;
+          break;
+        default:
+          break;
+      }
+    });
+    return summary;
+  }, [filteredAppointments]);
+
+  const weekdayLabel = useMemo(() => {
+    const raw = formatWeekday(selectedDate);
+    return raw.charAt(0).toUpperCase() + raw.slice(1);
+  }, [selectedDate]);
+
+  const handleStatusChange = (status: AppointmentStatus) => {
+    if (selectedAppointment) {
+      updateAppointmentStatus(selectedAppointment.id, status);
+    }
   };
 
-  const changePeriod = (p: Period) => setPeriod(p);
-  const shiftDate = (dir: number) => {
-    const d = new Date(startDate);
-    if (period === 'day') d.setDate(d.getDate() + dir);
-    if (period === 'week') d.setDate(d.getDate() + dir * 7);
-    if (period === 'month') d.setMonth(d.getMonth() + dir);
-    if (period === '3m') d.setMonth(d.getMonth() + dir * 3);
-    if (period === '6m') d.setMonth(d.getMonth() + dir * 6);
-    if (period === 'year') d.setFullYear(d.getFullYear() + dir);
-    setStartDate(d);
+  const handleSaveNote = () => {
+    if (selectedAppointment) {
+      updateAppointmentNote(selectedAppointment.id, noteDraft);
+    }
   };
 
-  // группировка по дате
-  const grouped = slots.reduce((acc, slot) => {
-    const day = slot.date.slice(0, 10);
-    acc[day] = acc[day] || {};
-    acc[day][slot.time] = acc[day][slot.time] || [];
-    acc[day][slot.time].push(slot);
-    return acc;
-  }, {} as Record<string, Record<string, Slot[]>>);
+  const renderAppointment = (appointment: Appointment) => {
+    const doctor = doctorMap.get(appointment.doctorId);
+    const assistant = appointment.assistantId
+      ? assistantMap.get(appointment.assistantId)
+      : undefined;
+    const isActive = appointment.id === selectedAppointmentId;
+
+    return (
+      <button
+        key={appointment.id}
+        onClick={() => setSelectedAppointmentId(appointment.id)}
+        className={`group relative flex w-full items-start gap-3 rounded-2xl border bg-white/80 p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700 dark:bg-slate-800/80 ${
+          isActive ? 'border-orange-400 shadow-lg ring-2 ring-orange-200 dark:ring-orange-400/40' : 'border-slate-200'
+        }`}
+      >
+        <div className="flex flex-col items-center gap-1 text-sm font-semibold text-slate-600 dark:text-slate-200">
+          <span>{appointment.time}</span>
+          <span className="text-xs font-medium text-slate-400">
+            {addMinutesToTime(appointment.time, appointment.duration)}
+          </span>
+        </div>
+        <div className="absolute left-6 top-8 h-3 w-3 -translate-x-1/2 rounded-full border-2 border-white bg-orange-400 shadow-md group-hover:bg-orange-500 dark:border-slate-900" />
+        <div className="ml-6 flex-1 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-semibold text-slate-900 dark:text-white">
+              {appointment.patient.name}
+            </span>
+            <span
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium transition-colors ${appointmentStatusMeta[appointment.status].badgeClassName}`}
+            >
+              {getStatusIcon(appointment.status)}
+              {appointmentStatusMeta[appointment.status].label}
+            </span>
+          </div>
+          <p className="text-sm text-slate-500 dark:text-slate-300">
+            {appointment.procedure}
+          </p>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-slate-400 dark:text-slate-400">
+            <span className="inline-flex items-center gap-1">
+              <MapPin className="h-3.5 w-3.5" />
+              {appointment.room}
+            </span>
+            {assistant ? (
+              <span className="inline-flex items-center gap-1">
+                <Stethoscope className="h-3.5 w-3.5" />
+                Ассистент: {assistant.name}
+              </span>
+            ) : null}
+            {doctor ? (
+              <span className="inline-flex items-center gap-1">
+                <UserRound className="h-3.5 w-3.5" />
+                {doctor.name}
+              </span>
+            ) : null}
+          </div>
+          {appointment.note ? (
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              {appointment.note}
+            </p>
+          ) : null}
+        </div>
+      </button>
+    );
+  };
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
-      <h2 className="text-2xl font-bold text-page">{titles[period]}</h2>
+    <section className="space-y-6">
+      <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+              Расписание приёмов
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-300">
+              {formatDateHuman(selectedDate, { day: 'numeric', month: 'long', year: 'numeric' })}{' '}
+              · {weekdayLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-3 py-2 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+              <button
+                type="button"
+                onClick={() => setSelectedDate((value) => nextDate(value, -1))}
+                className="rounded-full border border-transparent p-1 text-slate-500 transition hover:border-slate-200 hover:bg-slate-100 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+                aria-label="Предыдущий день"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <input
+                type="date"
+                className="rounded-xl border border-slate-200 px-3 py-1 text-sm font-medium text-slate-700 shadow-inner focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:border-orange-400"
+                value={toDateInputValue(selectedDate)}
+                onChange={(event) => setSelectedDate(event.target.value)}
+              />
+              <button
+                type="button"
+                onClick={() => setSelectedDate((value) => nextDate(value, 1))}
+                className="rounded-full border border-transparent p-1 text-slate-500 transition hover:border-slate-200 hover:bg-slate-100 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+                aria-label="Следующий день"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+            <select
+              value={selectedDoctorId}
+              onChange={(event) => setSelectedDoctorId(event.target.value)}
+              className="rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:border-orange-400"
+            >
+              <option value="all">Все врачи</option>
+              {doctors.map((doctor) => (
+                <option key={doctor.id} value={doctor.id}>
+                  {doctor.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
 
-      {/* переключатель периода */}
-      <div className="flex flex-wrap gap-2 items-center">
-        {(['day', 'week', 'month', '3m', '6m', 'year'] as Period[]).map((p) => (
-          <button
-            key={p}
-            onClick={() => changePeriod(p)}
-            className={`px-3 py-1 rounded-lg text-sm font-medium transition-all ${period === p ? 'bg-orange-500 text-white' : 'bg-card border border-page'}`}
-          >
-            {titles[p]}
-          </button>
-        ))}
-        <div className="flex items-center gap-2 ml-auto">
-          <button onClick={() => shiftDate(-1)} className="p-1 rounded bg-card"><ChevronLeft /></button>
-          <span className="text-sm">{startDate.toLocaleDateString('ru-RU')}</span>
-          <button onClick={() => shiftDate(1)} className="p-1 rounded bg-card"><ChevronRight /></button>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Всего визитов
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">
+              {totals.total}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50/70 p-4 shadow-sm dark:border-emerald-500/40 dark:bg-emerald-500/20">
+            <p className="text-xs font-medium uppercase tracking-wide text-emerald-600 dark:text-emerald-200">
+              Подтверждено
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-emerald-700 dark:text-emerald-100">
+              {totals.confirmed}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/20">
+            <p className="text-xs font-medium uppercase tracking-wide text-amber-600 dark:text-amber-200">
+              Ждут ответа
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-amber-700 dark:text-amber-100">
+              {totals.waiting}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-orange-200 bg-orange-50 p-4 shadow-sm dark:border-orange-500/40 dark:bg-orange-500/20">
+            <p className="text-xs font-medium uppercase tracking-wide text-orange-600 dark:text-orange-200">
+              Требуют внимания
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-orange-700 dark:text-orange-100">
+              {totals.followUp}
+            </p>
+          </div>
         </div>
       </div>
 
-      {/* таблица */}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm text-left">
-          <thead className="border-b border-page">
-            <tr>
-              <th className="py-2">Дата</th>
-              <th className="py-2">Время</th>
-              <th className="py-2">Кабинет</th>
-              <th className="py-2">Врач/Ассистент</th>
-              <th className="py-2">Пациент</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(grouped).map(([date, slotsByTime]) =>
-              Object.entries(slotsByTime).map(([time, list]) =>
-                list.map((slot) => (
-                  <tr key={slot.id} className="border-b border-page/30">
-                    <td className="py-2">{date}</td>
-                    <td className="py-2">{time}</td>
-                    <td className="py-2">
-                      {rooms[Math.floor(Math.random() * rooms.length)]}
-                    </td>
-                    <td className="py-2">{slot.doctor}</td>
-                    <td className="py-2">{slot.patient || <span className="italic">Свободно</span>}</td>
-                  </tr>
-                ))
-              )
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(260px,1fr)]">
+        <div className="space-y-6">
+          {doctorsForDate.length === 0 ? (
+            <div className="rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-10 text-center text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
+              {emptyMessage}
+            </div>
+          ) : (
+            doctorsForDate.map((doctor) => {
+              const appointmentsForDoctor = filteredAppointments.filter(
+                (appointment) => appointment.doctorId === doctor.id,
+              );
+              return (
+                <div
+                  key={doctor.id}
+                  className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm transition hover:border-orange-200 hover:shadow-md dark:border-slate-700 dark:bg-slate-900/60"
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="flex h-12 w-12 items-center justify-center rounded-full text-base font-semibold text-white shadow-lg"
+                        style={createDoctorAvatarStyle(doctor.avatarColor)}
+                      >
+                        {doctor.name
+                          .split(' ')
+                          .map((part) => part[0])
+                          .join('')
+                          .slice(0, 2)}
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                          {doctor.name}
+                        </p>
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                          {doctor.speciality}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400 dark:text-slate-500">
+                      <span className="inline-flex items-center gap-1">
+                        <Clock className="h-3.5 w-3.5" />
+                        {doctor.workingHours.start} – {doctor.workingHours.end}
+                      </span>
+                      <span className="inline-flex items-center gap-1">
+                        <Phone className="h-3.5 w-3.5" />
+                        {doctor.phone}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 space-y-4">
+                    {appointmentsForDoctor.length === 0 ? (
+                      <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-800/40 dark:text-slate-400">
+                        У врача нет приёмов на выбранную дату.
+                      </div>
+                    ) : (
+                      <div className="relative pl-4">
+                        <div className="absolute left-6 top-2 bottom-2 w-px bg-gradient-to-b from-orange-100 via-orange-200 to-transparent dark:from-orange-500/40 dark:via-orange-500/20" />
+                        <div className="space-y-3">
+                          {appointmentsForDoctor.map((appointment) => renderAppointment(appointment))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <aside className="space-y-4">
+          <div className="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Детали визита</h3>
+            {selectedAppointment ? (
+              <div className="mt-4 space-y-5">
+                <div className="space-y-2 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-inner dark:border-slate-700 dark:bg-slate-900">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                    {selectedAppointment.patient.name}
+                  </p>
+                  <div className="flex flex-col gap-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span className="inline-flex items-center gap-2">
+                      <Phone className="h-3.5 w-3.5" />
+                      {selectedAppointment.patient.phone}
+                    </span>
+                    {selectedAppointment.patient.notes ? (
+                      <span className="inline-flex items-start gap-2">
+                        <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-none" />
+                        {selectedAppointment.patient.notes}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="grid gap-3 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-inner dark:border-slate-700 dark:bg-slate-900">
+                  <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                    <span className="inline-flex items-center gap-1">
+                      <CalendarClock className="h-3.5 w-3.5" />
+                      {selectedAppointment.time} · {minutesToLabel(selectedAppointment.duration)}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <MapPin className="h-3.5 w-3.5" />
+                      {selectedAppointment.room}
+                    </span>
+                  </div>
+                  <div className="space-y-1 text-sm text-slate-600 dark:text-slate-300">
+                    <p className="font-medium">{selectedAppointment.procedure}</p>
+                    {selectedAppointment.note ? (
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
+                        {selectedAppointment.note}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-col gap-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span className="inline-flex items-center gap-1">
+                      <Stethoscope className="h-3.5 w-3.5" />
+                      {doctorMap.get(selectedAppointment.doctorId)?.name}
+                    </span>
+                    {selectedAppointment.assistantId ? (
+                      <span className="inline-flex items-center gap-1">
+                        <UserRound className="h-3.5 w-3.5" />
+                        Ассистент: {assistantMap.get(selectedAppointment.assistantId)?.name}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div>
+                    <label
+                      htmlFor="appointment-status"
+                      className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500"
+                    >
+                      Статус визита
+                    </label>
+                    <select
+                      id="appointment-status"
+                      value={selectedAppointment.status}
+                      onChange={(event) => handleStatusChange(event.target.value as AppointmentStatus)}
+                      className="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:border-orange-400"
+                    >
+                      {appointmentStatusSelectOptions.map((status) => (
+                        <option key={status} value={status}>
+                          {appointmentStatusMeta[status].label}
+                        </option>
+                      ))}
+                </select>
+                <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                  {appointmentStatusMeta[selectedAppointment.status].description}
+                </p>
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="appointment-note"
+                      className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500"
+                    >
+                      Комментарий администратора
+                    </label>
+                    <textarea
+                      id="appointment-note"
+                      value={noteDraft}
+                      onChange={(event) => setNoteDraft(event.target.value)}
+                      onBlur={handleSaveNote}
+                      rows={3}
+                      className="mt-1 w-full resize-none rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600 shadow-sm transition focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:border-orange-400"
+                      placeholder="Добавьте важные детали, которые нужно учесть перед приёмом"
+                    />
+                    <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                      Комментарий сохраняется автоматически при выходе из поля.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+                {emptyMessage}
+              </p>
             )}
-          </tbody>
-        </table>
+          </div>
+
+          <div className="rounded-3xl border border-slate-200 bg-gradient-to-br from-orange-50 via-white to-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:from-orange-500/20 dark:via-slate-900 dark:to-slate-900">
+            <h4 className="text-sm font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-200">
+              Подсказка администратора
+            </h4>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+              Используйте фильтры по врачу и статусу, чтобы видеть только те приёмы, которые
+              требуют подтверждения или подготовки. В деталях визита можно сразу обновить
+              статус и оставить заметку для команды.
+            </p>
+          </div>
+        </aside>
       </div>
-    </div>
+    </section>
   );
 }
+

--- a/src/components/VoiceAssistantPanel.tsx
+++ b/src/components/VoiceAssistantPanel.tsx
@@ -1,0 +1,328 @@
+import React, { useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Headphones,
+  Mic,
+  PhoneCall,
+  RefreshCcw,
+  Volume2,
+} from 'lucide-react';
+
+import { appointmentStatusMeta } from '../constants/appointmentStatus';
+import { useSchedule } from '../context/ScheduleContext';
+import type { CallTask } from '../data/schedule';
+import { tomorrowKey } from '../data/schedule';
+import { addMinutesToTime, formatDateHuman } from '../utils/date';
+
+const callStatusOrder: CallTask['status'][] = [
+  'calling',
+  'pending',
+  'no-answer',
+  'reschedule',
+  'confirmed',
+];
+
+const statusBadge: Record<CallTask['status'], { label: string; className: string }> = {
+  pending: {
+    label: 'Ожидает звонка',
+    className: 'border border-dashed border-slate-300 bg-slate-50 text-slate-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300',
+  },
+  calling: {
+    label: 'Соединение…',
+    className: 'border border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-500/40 dark:bg-blue-500/20 dark:text-blue-100',
+  },
+  confirmed: {
+    label: 'Пациент подтвердил',
+    className: 'border border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/20 dark:text-emerald-100',
+  },
+  reschedule: {
+    label: 'Просит перенести',
+    className: 'border border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100',
+  },
+  'no-answer': {
+    label: 'Не дозвонились',
+    className: 'border border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/20 dark:text-rose-100',
+  },
+};
+
+const scriptSteps = [
+  'Добрый день! Вас беспокоит клиника доктора Денисенко. Напоминаю о приёме завтра.',
+  'Пожалуйста, подтвердите, сможете ли прийти в назначенное время. Если нет — подберём удобный слот.',
+  'Уточните, есть ли противопоказания или пожелания. Напомните взять документы и средства оплаты.',
+  'Поблагодарите за ответ и завершите звонок с пожеланием хорошего дня.',
+];
+
+type CallOutcome = Exclude<CallTask['status'], 'pending' | 'calling'>;
+
+export default function VoiceAssistantPanel() {
+  const { appointments, doctors, callTasks, startCall, finishCall } = useSchedule();
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+
+  const tasks = useMemo(() => {
+    return callTasks
+      .filter((task) => task.scheduledFor.startsWith(tomorrowKey))
+      .sort((a, b) => {
+        const statusDiff = callStatusOrder.indexOf(a.status) - callStatusOrder.indexOf(b.status);
+        if (statusDiff !== 0) return statusDiff;
+        return a.scheduledFor.localeCompare(b.scheduledFor);
+      });
+  }, [callTasks]);
+
+  const appointmentMap = useMemo(
+    () => new Map(appointments.map((appointment) => [appointment.id, appointment])),
+    [appointments],
+  );
+
+  const doctorMap = useMemo(
+    () => new Map(doctors.map((doctor) => [doctor.id, doctor])),
+    [doctors],
+  );
+
+  const totals = useMemo(() => {
+    const summary = {
+      total: tasks.length,
+      confirmed: tasks.filter((task) => task.status === 'confirmed').length,
+      waiting: tasks.filter((task) => task.status === 'pending' || task.status === 'calling').length,
+      escalation: tasks.filter((task) => task.status === 'reschedule' || task.status === 'no-answer').length,
+    };
+    return summary;
+  }, [tasks]);
+
+  const handleStartCall = (taskId: string) => {
+    startCall(taskId);
+    setErrors((prev) => ({ ...prev, [taskId]: undefined }));
+  };
+
+  const handleOutcome = (task: CallTask, outcome: CallOutcome) => {
+    const noteValue = notes[task.id] ?? task.note ?? '';
+    if (outcome === 'reschedule' && noteValue.trim().length === 0) {
+      setErrors((prev) => ({ ...prev, [task.id]: 'Укажите желаемое время или причину переноса.' }));
+      return;
+    }
+    finishCall(task.id, outcome, noteValue);
+    setErrors((prev) => ({ ...prev, [task.id]: undefined }));
+  };
+
+  const tomorrowLabel = formatDateHuman(tomorrowKey, {
+    day: 'numeric',
+    month: 'long',
+  });
+
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Голосовой ассистент</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-300">
+              Звонки пациентам на {tomorrowLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <SummaryBadge icon={<Volume2 className="h-4 w-4" />}>
+              Всего: {totals.total}
+            </SummaryBadge>
+            <SummaryBadge icon={<CheckCircle2 className="h-4 w-4" />} tone="success">
+              Подтвердили: {totals.confirmed}
+            </SummaryBadge>
+            <SummaryBadge icon={<AlertTriangle className="h-4 w-4" />} tone="warning">
+              Требуют внимания: {totals.escalation}
+            </SummaryBadge>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.7fr)_minmax(260px,1fr)]">
+        <div className="space-y-4">
+          {tasks.map((task) => {
+            const appointment = appointmentMap.get(task.appointmentId);
+            const doctor = doctorMap.get(task.doctorId);
+            const noteValue = notes[task.id] ?? task.note ?? '';
+
+            return (
+              <article
+                key={task.id}
+                className="rounded-3xl border border-slate-200 bg-white/90 p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-orange-200 hover:shadow-md dark:border-slate-700 dark:bg-slate-900/60"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                      {task.patientName}
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">{task.patientPhone}</p>
+                  </div>
+                  <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${statusBadge[task.status].className}`}>
+                    {statusBadge[task.status].label}
+                  </span>
+                </div>
+
+                <div className="mt-3 grid gap-2 rounded-2xl border border-slate-200 bg-white/70 p-4 text-xs text-slate-500 shadow-inner dark:border-slate-700 dark:bg-slate-900">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="inline-flex items-center gap-1 text-slate-600 dark:text-slate-300">
+                      <PhoneCall className="h-3.5 w-3.5" />
+                      {task.scheduledFor.slice(11, 16)} · {appointment ? appointment.room : '—'}
+                    </span>
+                    {appointment ? (
+                      <span className="inline-flex items-center gap-1">
+                        <Headphones className="h-3.5 w-3.5" />
+                        {doctor?.name}
+                      </span>
+                    ) : null}
+                    {appointment ? (
+                      <span className="inline-flex items-center gap-1 text-slate-600 dark:text-slate-300">
+                        <Mic className="h-3.5 w-3.5" />
+                        {appointment.procedure}
+                      </span>
+                    ) : null}
+                  </div>
+                  {appointment ? (
+                    <div className="flex flex-wrap items-center gap-3 text-slate-500 dark:text-slate-400">
+                      <span>
+                        Время приёма: {appointment.time}–
+                        {addMinutesToTime(appointment.time, appointment.duration)}
+                      </span>
+                      <span>
+                        Статус: {appointmentStatusMeta[appointment.status].label}
+                      </span>
+                    </div>
+                  ) : null}
+                  {task.lastCallAt ? (
+                    <p>Последний звонок: {formatTime(task.lastCallAt)}</p>
+                  ) : null}
+                </div>
+
+                <div className="mt-3 space-y-2">
+                  <label className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                    <Mic className="h-3.5 w-3.5" />
+                    Заметка по звонку
+                  </label>
+                  <textarea
+                    value={noteValue}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setNotes((prev) => ({ ...prev, [task.id]: value }));
+                      if (value.trim().length > 0) {
+                        setErrors((prev) => ({ ...prev, [task.id]: undefined }));
+                      }
+                    }}
+                    rows={3}
+                    placeholder="Запишите ответ пациента или детали переноса"
+                    className="w-full resize-none rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600 shadow-sm transition focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+                  />
+                  {errors[task.id] ? (
+                    <p className="text-xs text-rose-500">{errors[task.id]}</p>
+                  ) : null}
+                </div>
+
+                <div className="mt-4 flex flex-wrap items-center gap-3">
+                  {task.status === 'pending' || task.status === 'no-answer' || task.status === 'reschedule' ? (
+                    <button
+                      type="button"
+                      onClick={() => handleStartCall(task.id)}
+                      className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-orange-400 to-amber-400 px-4 py-2 text-sm font-semibold text-white shadow transition hover:from-orange-500 hover:to-amber-500"
+                    >
+                      <PhoneCall className="h-4 w-4" />
+                      Начать звонок
+                    </button>
+                  ) : null}
+                  {task.status === 'calling' ? (
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleOutcome(task, 'confirmed')}
+                        className="inline-flex items-center gap-2 rounded-2xl bg-emerald-500/90 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-emerald-600"
+                      >
+                        <CheckCircle2 className="h-4 w-4" />
+                        Подтвердил
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleOutcome(task, 'reschedule')}
+                        className="inline-flex items-center gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 transition hover:border-amber-300 hover:bg-amber-100 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
+                      >
+                        <RefreshCcw className="h-4 w-4" />
+                        Перенос
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleOutcome(task, 'no-answer')}
+                        className="inline-flex items-center gap-2 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-600 transition hover:border-rose-300 hover:bg-rose-100 dark:border-rose-500/40 dark:bg-rose-500/20 dark:text-rose-100"
+                      >
+                        <AlertTriangle className="h-4 w-4" />
+                        Нет ответа
+                      </button>
+                    </div>
+                  ) : null}
+                  {task.status === 'confirmed' ? (
+                    <p className="text-sm font-medium text-emerald-600 dark:text-emerald-200">
+                      Пациент подтвердил участие. Статус обновлён в расписании.
+                    </p>
+                  ) : null}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+
+        <aside className="space-y-4">
+          <div className="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Скрипт звонка
+            </h3>
+            <ol className="mt-3 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+              {scriptSteps.map((step, index) => (
+                <li key={step} className="flex gap-3">
+                  <span className="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-orange-500/10 text-xs font-semibold text-orange-600 dark:bg-orange-500/20 dark:text-orange-200">
+                    {index + 1}
+                  </span>
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="rounded-3xl border border-slate-200 bg-gradient-to-br from-orange-50 via-white to-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:from-orange-500/20 dark:via-slate-900 dark:to-slate-900">
+            <h4 className="text-sm font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-200">
+              Советы по эффективности звонков
+            </h4>
+            <ul className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+              <li>Записывайте ключевые ответы пациента, чтобы врачу не пришлось повторно уточнять.</li>
+              <li>Если пациент просит перенос, предложите два альтернативных окна сразу в разговоре.</li>
+              <li>Для пациентов без ответа запланируйте повторный звонок и отметьте это в комментарии.</li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+const formatTime = (iso: string) => iso.slice(11, 16);
+
+interface SummaryBadgeProps {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+  tone?: 'default' | 'success' | 'warning';
+}
+
+function SummaryBadge({ icon, children, tone = 'default' }: SummaryBadgeProps) {
+  const toneClasses = {
+    default: 'bg-slate-100 text-slate-600 dark:bg-slate-900/60 dark:text-slate-300',
+    success: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-100',
+    warning: 'bg-amber-50 text-amber-700 dark:bg-amber-500/20 dark:text-amber-100',
+  }[tone];
+
+  return (
+    <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${toneClasses}`}>
+      {icon}
+      {children}
+    </span>
+  );
+}
+

--- a/src/constants/appointmentStatus.ts
+++ b/src/constants/appointmentStatus.ts
@@ -1,0 +1,67 @@
+import type { AppointmentStatus } from '../data/schedule';
+
+export interface AppointmentStatusMeta {
+  label: string;
+  description: string;
+  badgeClassName: string;
+}
+
+export const appointmentStatusOrder: AppointmentStatus[] = [
+  'needs-confirmation',
+  'needs-follow-up',
+  'scheduled',
+  'confirmed',
+  'checked-in',
+  'completed',
+  'cancelled',
+];
+
+export const appointmentStatusMeta: Record<AppointmentStatus, AppointmentStatusMeta> = {
+  scheduled: {
+    label: 'Запланировано',
+    description: 'Визит назначен и ожидает подтверждения пациента или доктора.',
+    badgeClassName:
+      'border-slate-200 bg-slate-50 text-slate-600 group-hover:border-slate-300 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200',
+  },
+  'needs-confirmation': {
+    label: 'Ждёт подтверждения',
+    description: 'Нужно связаться с пациентом и получить подтверждение.',
+    badgeClassName:
+      'border-amber-200 bg-amber-50 text-amber-700 group-hover:border-amber-300 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-200',
+  },
+  confirmed: {
+    label: 'Подтверждено',
+    description: 'Пациент подтвердил визит, можно готовить кабинет.',
+    badgeClassName:
+      'border-emerald-200 bg-emerald-50 text-emerald-700 group-hover:border-emerald-300 dark:border-emerald-500/40 dark:bg-emerald-500/20 dark:text-emerald-200',
+  },
+  'needs-follow-up': {
+    label: 'Нужен повторный контакт',
+    description: 'Голосовой ассистент не дозвонился, требуется внимание администратора.',
+    badgeClassName:
+      'border-orange-200 bg-orange-50 text-orange-700 group-hover:border-orange-300 dark:border-orange-500/40 dark:bg-orange-500/20 dark:text-orange-200',
+  },
+  'checked-in': {
+    label: 'Пациент в клинике',
+    description: 'Пациент отметился в клинике и ожидает приёма.',
+    badgeClassName:
+      'border-blue-200 bg-blue-50 text-blue-700 group-hover:border-blue-300 dark:border-blue-500/40 dark:bg-blue-500/20 dark:text-blue-200',
+  },
+  completed: {
+    label: 'Завершено',
+    description: 'Визит завершён, можно оформить документы.',
+    badgeClassName:
+      'border-emerald-200 bg-emerald-50 text-emerald-700 group-hover:border-emerald-300 dark:border-emerald-500/60 dark:bg-emerald-500/10 dark:text-emerald-100',
+  },
+  cancelled: {
+    label: 'Отменено',
+    description: 'Запись отменена, слот можно отдать другому пациенту.',
+    badgeClassName:
+      'border-rose-200 bg-rose-50 text-rose-700 group-hover:border-rose-300 dark:border-rose-500/40 dark:bg-rose-500/20 dark:text-rose-200',
+  },
+};
+
+export const appointmentStatusSelectOptions = appointmentStatusOrder.filter(
+  (status) => status !== 'needs-follow-up',
+);
+

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -1,0 +1,171 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+import {
+  Appointment,
+  AppointmentStatus,
+  Assistant,
+  CallTask,
+  Doctor,
+  DoctorConfirmation,
+  appointments as initialAppointments,
+  assistants as initialAssistants,
+  callTasks as initialCallTasks,
+  doctorConfirmations as initialDoctorConfirmations,
+  doctors as doctorList,
+  rooms as initialRooms,
+} from '../data/schedule';
+import { formatDateKey } from '../utils/date';
+
+type CallOutcome = 'confirmed' | 'reschedule' | 'no-answer';
+
+interface ScheduleContextValue {
+  doctors: Doctor[];
+  assistants: Assistant[];
+  rooms: string[];
+  appointments: Appointment[];
+  doctorConfirmations: DoctorConfirmation[];
+  callTasks: CallTask[];
+  updateAppointmentStatus: (id: string, status: AppointmentStatus) => void;
+  updateAppointmentNote: (id: string, note: string) => void;
+  confirmDoctorDay: (
+    doctorId: string,
+    date: string,
+    status: DoctorConfirmation['status'],
+    note?: string,
+  ) => void;
+  startCall: (taskId: string) => void;
+  finishCall: (taskId: string, outcome: CallOutcome, note?: string) => void;
+}
+
+const ScheduleContext = createContext<ScheduleContextValue | undefined>(undefined);
+
+const ensureDateKey = (value: string) => formatDateKey(new Date(value));
+
+export const ScheduleProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [appointments, setAppointments] = useState<Appointment[]>(() => initialAppointments);
+  const [doctorConfirmations, setDoctorConfirmations] = useState<DoctorConfirmation[]>(
+    () => initialDoctorConfirmations,
+  );
+  const [callTasks, setCallTasks] = useState<CallTask[]>(() => initialCallTasks);
+
+  const updateAppointmentStatus = useCallback((id: string, status: AppointmentStatus) => {
+    setAppointments((prev) =>
+      prev.map((appointment) =>
+        appointment.id === id ? { ...appointment, status } : appointment,
+      ),
+    );
+  }, []);
+
+  const updateAppointmentNote = useCallback((id: string, note: string) => {
+    setAppointments((prev) =>
+      prev.map((appointment) =>
+        appointment.id === id ? { ...appointment, note } : appointment,
+      ),
+    );
+  }, []);
+
+  const confirmDoctorDay = useCallback(
+    (doctorId: string, date: string, status: DoctorConfirmation['status'], note?: string) => {
+      const dateKey = ensureDateKey(date);
+      setDoctorConfirmations((prev) => {
+        const next = [...prev];
+        const index = next.findIndex(
+          (item) => item.doctorId === doctorId && item.date === dateKey,
+        );
+        const payload: DoctorConfirmation = {
+          doctorId,
+          date: dateKey,
+          status,
+          note: note?.trim() ? note.trim() : undefined,
+          updatedAt: new Date().toISOString(),
+        };
+        if (index >= 0) {
+          next[index] = { ...next[index], ...payload };
+        } else {
+          next.push(payload);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const startCall = useCallback((taskId: string) => {
+    setCallTasks((prev) =>
+      prev.map((task) =>
+        task.id === taskId
+          ? {
+              ...task,
+              status: 'calling',
+              attempts: task.status === 'calling' ? task.attempts : task.attempts + 1,
+              lastCallAt: new Date().toISOString(),
+            }
+          : task,
+      ),
+    );
+  }, []);
+
+  const finishCall = useCallback(
+    (taskId: string, outcome: CallOutcome, note?: string) => {
+      const relatedTask = callTasks.find((task) => task.id === taskId);
+      setCallTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                status: outcome,
+                note: note?.trim() ? note.trim() : undefined,
+                lastCallAt: new Date().toISOString(),
+              }
+            : task,
+        ),
+      );
+
+      if (relatedTask) {
+        setAppointments((prev) =>
+          prev.map((appointment) => {
+            if (appointment.id !== relatedTask.appointmentId) {
+              return appointment;
+            }
+            const nextStatus: AppointmentStatus =
+              outcome === 'confirmed' ? 'confirmed' : 'needs-follow-up';
+            return {
+              ...appointment,
+              status: nextStatus,
+              note: note?.trim() ? note.trim() : appointment.note,
+            };
+          }),
+        );
+      }
+    },
+    [callTasks],
+  );
+
+  const value = useMemo<ScheduleContextValue>(
+    () => ({
+      doctors: doctorList,
+      assistants: initialAssistants,
+      rooms: initialRooms,
+      appointments,
+      doctorConfirmations,
+      callTasks,
+      updateAppointmentStatus,
+      updateAppointmentNote,
+      confirmDoctorDay,
+      startCall,
+      finishCall,
+    }),
+    [appointments, doctorConfirmations, callTasks, confirmDoctorDay, finishCall, startCall, updateAppointmentNote, updateAppointmentStatus],
+  );
+
+  return <ScheduleContext.Provider value={value}>{children}</ScheduleContext.Provider>;
+};
+
+export const useSchedule = (): ScheduleContextValue => {
+  const context = useContext(ScheduleContext);
+  if (!context) {
+    throw new Error('useSchedule должен использоваться внутри ScheduleProvider');
+  }
+  return context;
+};
+

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -1,0 +1,339 @@
+import { addDays, formatDateKey } from '../utils/date';
+
+export type AppointmentStatus =
+  | 'scheduled'
+  | 'needs-confirmation'
+  | 'confirmed'
+  | 'checked-in'
+  | 'completed'
+  | 'cancelled'
+  | 'needs-follow-up';
+
+export interface PatientInfo {
+  name: string;
+  phone: string;
+  notes?: string;
+}
+
+export interface Appointment {
+  id: string;
+  date: string; // YYYY-MM-DD
+  time: string; // HH:mm
+  duration: number; // minutes
+  doctorId: string;
+  assistantId?: string;
+  room: string;
+  procedure: string;
+  status: AppointmentStatus;
+  patient: PatientInfo;
+  note?: string;
+}
+
+export interface Doctor {
+  id: string;
+  name: string;
+  speciality: string;
+  phone: string;
+  email: string;
+  avatarColor: string;
+  workingHours: {
+    start: string;
+    end: string;
+  };
+}
+
+export interface Assistant {
+  id: string;
+  name: string;
+}
+
+export interface DoctorConfirmation {
+  doctorId: string;
+  date: string;
+  status: 'pending' | 'confirmed' | 'needs-changes';
+  note?: string;
+  updatedAt?: string;
+}
+
+export interface CallTask {
+  id: string;
+  appointmentId: string;
+  doctorId: string;
+  patientName: string;
+  patientPhone: string;
+  scheduledFor: string;
+  status: 'pending' | 'calling' | 'confirmed' | 'reschedule' | 'no-answer';
+  attempts: number;
+  lastCallAt?: string;
+  note?: string;
+}
+
+const baseDate = new Date();
+export const todayKey = formatDateKey(baseDate);
+export const tomorrowKey = formatDateKey(addDays(baseDate, 1));
+export const dayAfterTomorrowKey = formatDateKey(addDays(baseDate, 2));
+
+export const rooms = ['Кабинет 1', 'Кабинет 2', 'Хирургический блок'];
+
+export const assistants: Assistant[] = [
+  { id: 'assistant-maria', name: 'Мария Антонова' },
+  { id: 'assistant-kirill', name: 'Кирилл Юматов' },
+  { id: 'assistant-vika', name: 'Виктория Шестакова' },
+];
+
+export const doctors: Doctor[] = [
+  {
+    id: 'doctor-denisenko',
+    name: 'Анастасия Денисенко',
+    speciality: 'Терапевт, ортопед',
+    phone: '+7 (921) 555-44-11',
+    email: 'denisenko@clinic.ru',
+    avatarColor: '#f97316',
+    workingHours: { start: '09:00', end: '17:00' },
+  },
+  {
+    id: 'doctor-lebedeva',
+    name: 'Мария Лебедева',
+    speciality: 'Хирург-имплантолог',
+    phone: '+7 (921) 555-88-22',
+    email: 'lebedeva@clinic.ru',
+    avatarColor: '#6366f1',
+    workingHours: { start: '10:00', end: '18:00' },
+  },
+  {
+    id: 'doctor-smirnov',
+    name: 'Илья Смирнов',
+    speciality: 'Детский стоматолог',
+    phone: '+7 (921) 777-12-34',
+    email: 'smirnov@clinic.ru',
+    avatarColor: '#0ea5e9',
+    workingHours: { start: '08:30', end: '15:30' },
+  },
+];
+
+export const appointments: Appointment[] = [
+  {
+    id: 'apt-1',
+    date: todayKey,
+    time: '09:00',
+    duration: 50,
+    doctorId: 'doctor-denisenko',
+    assistantId: 'assistant-maria',
+    room: 'Кабинет 1',
+    procedure: 'Первичная консультация и диагностика',
+    status: 'checked-in',
+    patient: {
+      name: 'Сергей Иванов',
+      phone: '+7 (921) 100-20-30',
+      notes: 'Аллергия на лидокаин, бережный подход',
+    },
+    note: 'Подготовить снимок 3D, повторить рекомендации по гигиене.',
+  },
+  {
+    id: 'apt-2',
+    date: todayKey,
+    time: '10:15',
+    duration: 60,
+    doctorId: 'doctor-denisenko',
+    assistantId: 'assistant-maria',
+    room: 'Кабинет 1',
+    procedure: 'Лечение кариеса 1.6',
+    status: 'confirmed',
+    patient: {
+      name: 'Алина Кузнецова',
+      phone: '+7 (921) 555-10-70',
+    },
+    note: 'Пациент просил напомнить о скидке по ДМС.',
+  },
+  {
+    id: 'apt-3',
+    date: todayKey,
+    time: '12:00',
+    duration: 90,
+    doctorId: 'doctor-lebedeva',
+    assistantId: 'assistant-kirill',
+    room: 'Хирургический блок',
+    procedure: 'Удаление восьмерки справа снизу',
+    status: 'scheduled',
+    patient: {
+      name: 'Игорь Сидоров',
+      phone: '+7 (921) 700-40-40',
+    },
+    note: 'Проверить свежесть набора имплантов.',
+  },
+  {
+    id: 'apt-4',
+    date: todayKey,
+    time: '14:30',
+    duration: 30,
+    doctorId: 'doctor-smirnov',
+    assistantId: 'assistant-vika',
+    room: 'Кабинет 2',
+    procedure: 'Детская гигиена, 8 лет',
+    status: 'completed',
+    patient: {
+      name: 'Егор Павликов',
+      phone: '+7 (921) 880-11-33',
+      notes: 'С собой мама, просьба подарить наклейку.',
+    },
+    note: 'Назначить повтор через 6 месяцев.',
+  },
+  {
+    id: 'apt-5',
+    date: tomorrowKey,
+    time: '09:00',
+    duration: 60,
+    doctorId: 'doctor-denisenko',
+    assistantId: 'assistant-maria',
+    room: 'Кабинет 1',
+    procedure: 'Плановая профессиональная чистка',
+    status: 'needs-confirmation',
+    patient: {
+      name: 'Надежда Алексеева',
+      phone: '+7 (921) 120-90-10',
+      notes: 'Предпочитает звонки утром, предупредить об оплате картой.',
+    },
+    note: 'Подготовить индивидуальные рекомендации по щетке.',
+  },
+  {
+    id: 'apt-6',
+    date: tomorrowKey,
+    time: '10:30',
+    duration: 45,
+    doctorId: 'doctor-denisenko',
+    assistantId: 'assistant-maria',
+    room: 'Кабинет 1',
+    procedure: 'Замена временной пломбы 2.4',
+    status: 'scheduled',
+    patient: {
+      name: 'Максим Трофимов',
+      phone: '+7 (921) 340-11-99',
+    },
+    note: 'Необходимо согласовать время с его работой, возможен перенос.',
+  },
+  {
+    id: 'apt-7',
+    date: tomorrowKey,
+    time: '12:00',
+    duration: 120,
+    doctorId: 'doctor-lebedeva',
+    assistantId: 'assistant-kirill',
+    room: 'Хирургический блок',
+    procedure: 'Установка импланта Astra Tech',
+    status: 'confirmed',
+    patient: {
+      name: 'Александр Громов',
+      phone: '+7 (921) 500-66-99',
+    },
+    note: 'Заказать доп. набор абатментов, проверка КТ перед приемом.',
+  },
+  {
+    id: 'apt-8',
+    date: tomorrowKey,
+    time: '15:00',
+    duration: 30,
+    doctorId: 'doctor-smirnov',
+    assistantId: 'assistant-vika',
+    room: 'Кабинет 2',
+    procedure: 'Герметизация фиссур',
+    status: 'needs-confirmation',
+    patient: {
+      name: 'Семён Ларионов',
+      phone: '+7 (921) 660-44-21',
+      notes: 'Требуется письменное согласие от родителей.',
+    },
+    note: 'Подготовить набор для герметизации и наклейки для ребёнка.',
+  },
+  {
+    id: 'apt-9',
+    date: dayAfterTomorrowKey,
+    time: '09:30',
+    duration: 50,
+    doctorId: 'doctor-denisenko',
+    assistantId: 'assistant-maria',
+    room: 'Кабинет 1',
+    procedure: 'Контроль после лечения канала',
+    status: 'scheduled',
+    patient: {
+      name: 'Ирина Полянская',
+      phone: '+7 (921) 410-70-12',
+    },
+  },
+  {
+    id: 'apt-10',
+    date: dayAfterTomorrowKey,
+    time: '11:00',
+    duration: 30,
+    doctorId: 'doctor-smirnov',
+    assistantId: 'assistant-vika',
+    room: 'Кабинет 2',
+    procedure: 'Осмотр после ортодонтического лечения',
+    status: 'scheduled',
+    patient: {
+      name: 'Дарья Чернова',
+      phone: '+7 (921) 320-55-43',
+    },
+    note: 'Принести снимки с прошлого приема.',
+  },
+];
+
+export const doctorConfirmations: DoctorConfirmation[] = doctors.map((doctor) => ({
+  doctorId: doctor.id,
+  date: tomorrowKey,
+  status: doctor.id === 'doctor-lebedeva' ? 'confirmed' : 'pending',
+  note:
+    doctor.id === 'doctor-lebedeva'
+      ? 'Готова начать в 12:00, ассистент предупрежден.'
+      : undefined,
+  updatedAt: doctor.id === 'doctor-lebedeva' ? new Date().toISOString() : undefined,
+}));
+
+export const callTasks: CallTask[] = [
+  {
+    id: 'call-apt-5',
+    appointmentId: 'apt-5',
+    doctorId: 'doctor-denisenko',
+    patientName: 'Надежда Алексеева',
+    patientPhone: '+7 (921) 120-90-10',
+    scheduledFor: `${tomorrowKey}T09:00:00`,
+    status: 'pending',
+    attempts: 0,
+  },
+  {
+    id: 'call-apt-6',
+    appointmentId: 'apt-6',
+    doctorId: 'doctor-denisenko',
+    patientName: 'Максим Трофимов',
+    patientPhone: '+7 (921) 340-11-99',
+    scheduledFor: `${tomorrowKey}T10:30:00`,
+    status: 'pending',
+    attempts: 1,
+    lastCallAt: `${todayKey}T08:30:00`,
+    note: 'Вчера не ответил на звонок, повторить утром.',
+  },
+  {
+    id: 'call-apt-7',
+    appointmentId: 'apt-7',
+    doctorId: 'doctor-lebedeva',
+    patientName: 'Александр Громов',
+    patientPhone: '+7 (921) 500-66-99',
+    scheduledFor: `${tomorrowKey}T12:00:00`,
+    status: 'confirmed',
+    attempts: 1,
+    lastCallAt: `${todayKey}T11:00:00`,
+    note: 'Пациент подтвердил визит, просил подготовить договор.',
+  },
+  {
+    id: 'call-apt-8',
+    appointmentId: 'apt-8',
+    doctorId: 'doctor-smirnov',
+    patientName: 'Семён Ларионов',
+    patientPhone: '+7 (921) 660-44-21',
+    scheduledFor: `${tomorrowKey}T15:00:00`,
+    status: 'no-answer',
+    attempts: 2,
+    lastCallAt: `${todayKey}T12:45:00`,
+    note: 'Не взяли трубку, попробовать позвонить родителям повторно.',
+  },
+];
+

--- a/src/index.css
+++ b/src/index.css
@@ -2,3 +2,65 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --color-bg-page: 248 250 252;
+    --color-text-page: 30 41 59;
+    --color-bg-card: 255 255 255;
+    --color-border-page: 226 232 240;
+    --color-accent: 249 115 22;
+  }
+
+  [data-theme='dark'] {
+    --color-bg-page: 15 23 42;
+    --color-text-page: 226 232 240;
+    --color-bg-card: 30 41 59;
+    --color-border-page: 71 85 105;
+    --color-accent: 251 191 36;
+  }
+
+  body {
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background-color: rgb(var(--color-bg-page));
+    color: rgb(var(--color-text-page));
+  }
+}
+
+@layer utilities {
+  .bg-page {
+    background-color: rgb(var(--color-bg-page));
+  }
+
+  .bg-card {
+    background-color: rgb(var(--color-bg-card));
+  }
+
+  .bg-card\/80 {
+    background-color: rgb(var(--color-bg-card) / 0.8);
+  }
+
+  .text-page {
+    color: rgb(var(--color-text-page));
+  }
+
+  .text-page\/60 {
+    color: rgb(var(--color-text-page) / 0.6);
+  }
+
+  .text-page\/70 {
+    color: rgb(var(--color-text-page) / 0.7);
+  }
+
+  .text-page\/80 {
+    color: rgb(var(--color-text-page) / 0.8);
+  }
+
+  .border-page {
+    border-color: rgb(var(--color-border-page));
+  }
+
+  .accent {
+    color: rgb(var(--color-accent));
+  }
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,51 @@
+export const formatDateKey = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const parseDateKey = (value: string): Date => {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
+
+export const addDays = (date: Date, amount: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + amount);
+  return result;
+};
+
+export const formatDateHuman = (
+  value: string,
+  options: Intl.DateTimeFormatOptions = {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  },
+): string => {
+  return parseDateKey(value).toLocaleDateString('ru-RU', options);
+};
+
+export const formatWeekday = (value: string): string => {
+  return parseDateKey(value).toLocaleDateString('ru-RU', { weekday: 'long' });
+};
+
+export const compareTime = (a: string, b: string): number => {
+  return a.localeCompare(b, undefined, { numeric: true });
+};
+
+export const minutesBetween = (start: string, end: string): number => {
+  const [startH, startM] = start.split(':').map(Number);
+  const [endH, endM] = end.split(':').map(Number);
+  return (endH - startH) * 60 + (endM - startM);
+};
+
+export const addMinutesToTime = (time: string, minutes: number): string => {
+  const [hours, mins] = time.split(':').map(Number);
+  const total = hours * 60 + mins + minutes;
+  const totalHours = Math.floor(total / 60);
+  const totalMinutes = total % 60;
+  return `${String(totalHours).padStart(2, '0')}:${String(totalMinutes).padStart(2, '0')}`;
+};
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: ['class', '[data-theme="dark"]'],
   theme: { extend: {} },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- introduce structured mock data and a shared schedule context to drive appointments, doctor confirmations, and call tasks
- rebuild the daily schedule, dashboard, and calendar views to surface actionable metrics with inline editing
- add dedicated panels for doctor confirmation of tomorrow's roster and a voice assistant queue to manage patient calls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c83dfc7e408325b0cf5a31d791fc0c