### PR TITLE
Implement client-side auth context with Dexie and protected routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dental-portal",
       "version": "0.1.0",
       "dependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "bcryptjs": "^3.0.2",
+        "dexie": "^4.2.0",
         "lucide-react": "^0.541.0",
         "nodemailer": "^7.0.5",
         "react": "^18.2.0",
@@ -2190,6 +2193,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
@@ -2365,6 +2374,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2609,6 +2627,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/dexie": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
+      "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
+      "license": "Apache-2.0"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "bcryptjs": "^3.0.2",
+    "dexie": "^4.2.0",
     "lucide-react": "^0.541.0",
     "nodemailer": "^7.0.5",
     "react": "^18.2.0",

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useAuth } from '../context/AuthContext';
+
+interface ProtectedRouteProps {
+  children?: React.ReactNode;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { currentUser, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-page text-page">
+        <p className="text-sm text-page/70">Проверяем доступ...</p>
+      </div>
+    );
+  }
+
+  if (!currentUser) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (children) {
+    return <>{children}</>;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,150 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import bcrypt from 'bcryptjs';
+
+import { AuthUser, authDb, authDbReady } from '../services/authDb';
+
+export type AuthErrorCode = 'user-not-found' | 'invalid-password' | 'needs-password-setup';
+
+export class AuthError extends Error {
+  public code: AuthErrorCode;
+  public user?: AuthUser;
+
+  constructor(code: AuthErrorCode, message: string, user?: AuthUser) {
+    super(message);
+    this.name = 'AuthError';
+    this.code = code;
+    this.user = user;
+  }
+}
+
+interface AuthContextValue {
+  currentUser: AuthUser | null;
+  users: AuthUser[];
+  loading: boolean;
+  login: (email: string, password: string) => Promise<AuthUser>;
+  logout: () => Promise<void>;
+  completeAdminSetup: (userId: number, password: string) => Promise<AuthUser>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const SESSION_STORAGE_KEY = 'dental-portal-active-user';
+
+export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [users, setUsers] = useState<AuthUser[]>([]);
+  const [currentUser, setCurrentUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadUsers = useCallback(async () => {
+    await authDbReady;
+    const allUsers = await authDb.users.toArray();
+    setUsers(allUsers);
+    return allUsers;
+  }, []);
+
+  useEffect(() => {
+    const initialize = async () => {
+      const allUsers = await loadUsers();
+      const storedId = localStorage.getItem(SESSION_STORAGE_KEY);
+      if (storedId) {
+        const parsedId = Number(storedId);
+        if (!Number.isNaN(parsedId)) {
+          const savedUser = allUsers.find((user) => user.id === parsedId);
+          if (savedUser) {
+            setCurrentUser(savedUser);
+          } else {
+            localStorage.removeItem(SESSION_STORAGE_KEY);
+          }
+        } else {
+          localStorage.removeItem(SESSION_STORAGE_KEY);
+        }
+      }
+      setLoading(false);
+    };
+
+    void initialize();
+  }, [loadUsers]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      await authDbReady;
+      const normalizedEmail = email.trim().toLowerCase();
+      const user = await authDb.users.where('email').equals(normalizedEmail).first();
+      if (!user) {
+        throw new AuthError('user-not-found', 'Пользователь не найден');
+      }
+
+      if (user.needsPasswordSetup) {
+        throw new AuthError('needs-password-setup', 'Требуется первичная установка пароля', user);
+      }
+
+      const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+      if (!isPasswordValid) {
+        throw new AuthError('invalid-password', 'Неверный пароль');
+      }
+
+      setCurrentUser(user);
+      if (typeof user.id === 'number') {
+        localStorage.setItem(SESSION_STORAGE_KEY, String(user.id));
+      }
+
+      return user;
+    },
+    [],
+  );
+
+  const completeAdminSetup = useCallback(
+    async (userId: number, password: string) => {
+      await authDbReady;
+      const existingUser = await authDb.users.get(userId);
+      if (!existingUser) {
+        throw new AuthError('user-not-found', 'Пользователь не найден');
+      }
+
+      const passwordHash = await bcrypt.hash(password, 10);
+      await authDb.users.update(userId, {
+        passwordHash,
+        needsPasswordSetup: false,
+      });
+
+      const allUsers = await loadUsers();
+      const updatedUser = allUsers.find((user) => user.id === userId);
+      if (!updatedUser) {
+        throw new AuthError('user-not-found', 'Пользователь не найден');
+      }
+
+      setCurrentUser(updatedUser);
+      localStorage.setItem(SESSION_STORAGE_KEY, String(userId));
+
+      return updatedUser;
+    },
+    [loadUsers],
+  );
+
+  const logout = useCallback(async () => {
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+    setCurrentUser(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      currentUser,
+      users,
+      loading,
+      login,
+      logout,
+      completeAdminSetup,
+    }),
+    [completeAdminSetup, currentUser, loading, login, logout, users],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth должен использоваться внутри AuthProvider');
+  }
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,31 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import Login from './pages/Login';
+
+import ProtectedRoute from './components/ProtectedRoute';
+import { AuthProvider } from './context/AuthContext';
+import Approve from './pages/Approve';
 import Dashboard from './pages/Dashboard';
+import Login from './pages/Login';
 import Register from './pages/Register';
+import Reject from './pages/Reject';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Login />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="*" element={<Navigate to="/" />} />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Login />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="/approve" element={<Approve />} />
+            <Route path="/reject" element={<Reject />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   </React.StrictMode>,
 );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+import { useAuth, AuthError } from '../context/AuthContext';
+import { AuthUser } from '../services/authDb';
 import { useDark } from '../hooks/useDark';
 
 export default function Login() {
@@ -7,18 +10,90 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [visible, setVisible] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [setupUser, setSetupUser] = useState<AuthUser | null>(null);
+  const [setupPassword, setSetupPassword] = useState('');
+  const [setupPasswordConfirm, setSetupPasswordConfirm] = useState('');
+  const [setupError, setSetupError] = useState<string | null>(null);
+  const [isSavingSetup, setIsSavingSetup] = useState(false);
+
   const navigate = useNavigate();
+  const { login, completeAdminSetup } = useAuth();
 
   React.useEffect(() => setVisible(true), []);
 
-  const handleLogin = (e: React.FormEvent) => {
-    e.preventDefault();
-    localStorage.setItem('user', JSON.stringify({ email }));
-    navigate('/dashboard');
+  const handleLogin = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await login(email.trim().toLowerCase(), password);
+      navigate('/dashboard');
+    } catch (err) {
+      if (err instanceof AuthError && err.code === 'needs-password-setup' && err.user) {
+        setSetupUser(err.user);
+        setSetupPassword('');
+        setSetupPasswordConfirm('');
+        setSetupError(null);
+      } else if (err instanceof AuthError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось выполнить вход. Попробуйте ещё раз.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCompleteSetup = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!setupUser?.id) {
+      setSetupError('Не удалось определить пользователя для настройки.');
+      return;
+    }
+
+    if (setupPassword.length < 6) {
+      setSetupError('Пароль должен содержать не менее 6 символов.');
+      return;
+    }
+
+    if (setupPassword !== setupPasswordConfirm) {
+      setSetupError('Пароли не совпадают.');
+      return;
+    }
+
+    setSetupError(null);
+    setIsSavingSetup(true);
+
+    try {
+      await completeAdminSetup(setupUser.id, setupPassword);
+      setSetupUser(null);
+      setSetupPassword('');
+      setSetupPasswordConfirm('');
+      navigate('/dashboard');
+    } catch (err) {
+      if (err instanceof AuthError) {
+        setSetupError(err.message);
+      } else {
+        setSetupError('Не удалось сохранить пароль. Попробуйте позже.');
+      }
+    } finally {
+      setIsSavingSetup(false);
+    }
+  };
+
+  const closeSetupDialog = () => {
+    setSetupUser(null);
+    setSetupPassword('');
+    setSetupPasswordConfirm('');
+    setSetupError(null);
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 bg-page text-page">
+    <div className="min-h-screen flex items-center justify-center p-4 bg-page text-page relative">
       <button
         onClick={toggleDark}
         className="absolute top-4 right-4 p-2 rounded-full bg-card border border-page"
@@ -36,12 +111,14 @@ export default function Login() {
 
         <h1 className="text-2xl font-bold text-center">Клиника доктора Денисенко</h1>
 
+        {error ? <p className="text-sm text-red-500 text-center">{error}</p> : null}
+
         <input
           type="email"
           required
           placeholder="E-mail"
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(event) => setEmail(event.target.value)}
           className="w-full bg-card border border-page rounded-lg px-4 py-3 text-page focus:ring-2 focus:ring-orange-500"
         />
 
@@ -50,19 +127,73 @@ export default function Login() {
           required
           placeholder="Пароль"
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          onChange={(event) => setPassword(event.target.value)}
           className="w-full bg-card border border-page rounded-lg px-4 py-3 text-page focus:ring-2 focus:ring-orange-500"
         />
 
         <button
           type="submit"
-          className="w-full bg-gradient-to-r from-orange-500 to-yellow-500 text-white font-semibold rounded-lg shadow-md hover:from-orange-600 hover:to-yellow-600 transition-all animate-pulse"
+          disabled={isSubmitting}
+          className="w-full bg-gradient-to-r from-orange-500 to-yellow-500 text-white font-semibold rounded-lg shadow-md hover:from-orange-600 hover:to-yellow-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          Войти
+          {isSubmitting ? 'Входим...' : 'Войти'}
         </button>
 
-        <p className="text-xs text-center text-page/60">Демо-режим: любые данные работают</p>
+        <p className="text-xs text-center text-page/60">
+          Для входа используйте e-mail администратора клиники.
+        </p>
       </form>
+
+      {setupUser ? (
+        <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/50 px-4">
+          <form
+            onSubmit={handleCompleteSetup}
+            className="w-full max-w-md space-y-4 rounded-2xl border border-page bg-card p-6 shadow-2xl"
+          >
+            <h2 className="text-xl font-semibold text-page text-center">Установка пароля администратора</h2>
+            <p className="text-sm text-page/70 text-center">
+              Завершите настройку аккаунта {setupUser.email}, придумайте надёжный пароль и сохраните его.
+            </p>
+
+            {setupError ? <p className="text-sm text-red-500 text-center">{setupError}</p> : null}
+
+            <input
+              type="password"
+              required
+              placeholder="Новый пароль"
+              value={setupPassword}
+              onChange={(event) => setSetupPassword(event.target.value)}
+              className="w-full bg-card border border-page rounded-lg px-4 py-3 text-page focus:ring-2 focus:ring-orange-500"
+            />
+
+            <input
+              type="password"
+              required
+              placeholder="Повторите пароль"
+              value={setupPasswordConfirm}
+              onChange={(event) => setSetupPasswordConfirm(event.target.value)}
+              className="w-full bg-card border border-page rounded-lg px-4 py-3 text-page focus:ring-2 focus:ring-orange-500"
+            />
+
+            <div className="flex items-center justify-between gap-4 pt-2">
+              <button
+                type="button"
+                onClick={closeSetupDialog}
+                className="flex-1 rounded-lg border border-page px-4 py-2 text-sm font-medium text-page hover:bg-page/10"
+              >
+                Отмена
+              </button>
+              <button
+                type="submit"
+                disabled={isSavingSetup}
+                className="flex-1 rounded-lg bg-gradient-to-r from-orange-500 to-yellow-500 px-4 py-2 text-sm font-semibold text-white shadow-md hover:from-orange-600 hover:to-yellow-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSavingSetup ? 'Сохраняем...' : 'Сохранить пароль'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/services/authDb.ts
+++ b/src/services/authDb.ts
@@ -1,0 +1,40 @@
+import Dexie, { Table } from 'dexie';
+
+export interface AuthUser {
+  id?: number;
+  email: string;
+  passwordHash: string;
+  role: string;
+  needsPasswordSetup: boolean;
+}
+
+class AuthDatabase extends Dexie {
+  public users!: Table<AuthUser, number>;
+
+  constructor() {
+    super('dentalPortalAuth');
+    this.version(1).stores({
+      users: '++id, email',
+    });
+  }
+}
+
+export const authDb = new AuthDatabase();
+
+const ADMIN_EMAIL = 'crack-angel@yandex.ru';
+
+const initializeAuthDb = (async () => {
+  await authDb.open();
+
+  const admin = await authDb.users.where('email').equals(ADMIN_EMAIL).first();
+  if (!admin) {
+    await authDb.users.add({
+      email: ADMIN_EMAIL,
+      passwordHash: '',
+      role: 'admin',
+      needsPasswordSetup: true,
+    });
+  }
+})();
+
+export const authDbReady = initializeAuthDb;


### PR DESCRIPTION
## Summary
- add IndexedDB auth storage using Dexie with default admin record seeded
- implement React auth context with session persistence and admin password setup support
- update login flow and routing to use bcryptjs verification and protected routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9fa577fe8832597d6ec5649806247