### PR TITLE
Implement registration workflows and admin pages

### DIFF
--- a/src/components/PortalHeader.tsx
+++ b/src/components/PortalHeader.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { LogOut, Moon, Sun, UsersRound, ClipboardCheck, Ban } from 'lucide-react';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+
+import { useDark } from '../hooks/useDark';
+import { useAuth } from '../context/AuthContext';
+
+interface PortalHeaderProps {
+  title: string;
+  subtitle?: string;
+}
+
+const navItems = [
+  { to: '/dashboard', label: 'Дашборд', icon: UsersRound },
+  { to: '/approve', label: 'Заявки', icon: ClipboardCheck },
+  { to: '/reject', label: 'Отказы', icon: Ban },
+];
+
+const linkBaseClasses =
+  'flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium transition-colors';
+
+export default function PortalHeader({ title, subtitle }: PortalHeaderProps) {
+  const [dark, toggleDark] = useDark();
+  const { logout, currentUser } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/');
+  };
+
+  return (
+    <header className="sticky top-0 z-20 border-b border-page bg-card/80 backdrop-blur-lg shadow-sm">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div>
+          <h1 className="text-lg font-semibold text-page sm:text-xl">{title}</h1>
+          {subtitle ? (
+            <p className="hidden text-xs text-page/60 sm:block">{subtitle}</p>
+          ) : null}
+        </div>
+
+        <nav className="hidden items-center gap-2 md:flex">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `${linkBaseClasses} ${
+                    isActive
+                      ? 'bg-page/20 text-page'
+                      : 'text-page/70 hover:bg-page/20 hover:text-page'
+                  }`
+                }
+              >
+                <Icon className="h-4 w-4" />
+                {item.label}
+              </NavLink>
+            );
+          })}
+        </nav>
+
+        <div className="flex items-center gap-2">
+          {currentUser ? (
+            <span className="hidden text-xs text-page/60 sm:block">
+              {currentUser.name ?? currentUser.email}
+            </span>
+          ) : null}
+          <button
+            onClick={toggleDark}
+            className="rounded-full border border-page bg-card p-2"
+            title="Переключить тему"
+            type="button"
+          >
+            {dark ? <Moon className="h-4 w-4 text-page" /> : <Sun className="h-4 w-4 text-page" />}
+          </button>
+          <button
+            onClick={handleLogout}
+            className="hidden items-center gap-2 rounded-full bg-gradient-to-r from-orange-500 to-yellow-500 px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:from-orange-600 hover:to-yellow-600 sm:flex"
+            type="button"
+          >
+            <LogOut className="h-4 w-4" />
+            Выйти
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-page/60 px-4 py-2 md:hidden">
+        <div className="text-xs text-page/70">{currentUser?.name ?? currentUser?.email}</div>
+        <div className="flex items-center gap-1">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const isActive = location.pathname === item.to;
+            return (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={`${
+                  isActive
+                    ? 'bg-gradient-to-r from-orange-500 to-yellow-500 text-white'
+                    : 'border border-page text-page'
+                } flex items-center gap-1 rounded-full px-3 py-1 text-xs`}
+              >
+                <Icon className="h-3 w-3" />
+                {item.label}
+              </NavLink>
+            );
+          })}
+          <button
+            onClick={handleLogout}
+            className="rounded-full border border-page px-3 py-1 text-xs text-page"
+            type="button"
+          >
+            Выйти
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/context/RegistrationContext.tsx
+++ b/src/context/RegistrationContext.tsx
@@ -1,0 +1,207 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export type RegistrationRole = 'reception' | 'doctor' | 'assistant' | 'admin';
+export type RegistrationStatus = 'pending' | 'approved' | 'rejected';
+
+export interface RegistrationRequest {
+  id: string;
+  email: string;
+  fullName: string;
+  role: RegistrationRole;
+  note?: string;
+  status: RegistrationStatus;
+  createdAt: string;
+  processedAt?: string;
+  processedBy?: string;
+  decisionNote?: string;
+  assignedUserId?: number;
+}
+
+interface RegistrationContextValue {
+  requests: RegistrationRequest[];
+  pendingRequests: RegistrationRequest[];
+  approvedRequests: RegistrationRequest[];
+  rejectedRequests: RegistrationRequest[];
+  createRequest: (payload: RegistrationPayload) => RegistrationRequest;
+  updateRequestStatus: (
+    id: string,
+    status: RegistrationStatus,
+    options?: {
+      processedBy?: string;
+      note?: string;
+      assignedUserId?: number;
+    },
+  ) => RegistrationRequest | undefined;
+  getRequestById: (id: string) => RegistrationRequest | undefined;
+}
+
+export interface RegistrationPayload {
+  email: string;
+  fullName: string;
+  role: RegistrationRole;
+  note?: string;
+}
+
+const RegistrationContext = createContext<RegistrationContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'dental-portal-registration-requests';
+
+const loadRequests = (): RegistrationRequest[] => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as RegistrationRequest[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((item) => ({
+        ...item,
+        createdAt: item.createdAt,
+        processedAt: item.processedAt,
+      }))
+      .filter((item) => typeof item.email === 'string' && typeof item.fullName === 'string');
+  } catch (error) {
+    console.error('Не удалось загрузить заявки на регистрацию', error);
+    return [];
+  }
+};
+
+const persistRequests = (requests: RegistrationRequest[]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(requests));
+  } catch (error) {
+    console.error('Не удалось сохранить заявки на регистрацию', error);
+  }
+};
+
+const createRequestId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `req-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+export const RegistrationProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [requests, setRequests] = useState<RegistrationRequest[]>(() => loadRequests());
+
+  useEffect(() => {
+    persistRequests(requests);
+  }, [requests]);
+
+  const createRequest = useCallback(
+    (payload: RegistrationPayload) => {
+      const normalizedEmail = payload.email.trim().toLowerCase();
+
+      if (
+        requests.some(
+          (request) => request.email.toLowerCase() === normalizedEmail && request.status === 'pending',
+        )
+      ) {
+        throw new Error('Заявка с таким e-mail уже ожидает рассмотрения.');
+      }
+
+      const request: RegistrationRequest = {
+        id: createRequestId(),
+        email: normalizedEmail,
+        fullName: payload.fullName.trim(),
+        role: payload.role,
+        note: payload.note?.trim() ? payload.note.trim() : undefined,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+      };
+
+      setRequests((prev) => [...prev, request]);
+      return request;
+    },
+    [requests],
+  );
+
+  const updateRequestStatus = useCallback(
+    (
+      id: string,
+      status: RegistrationStatus,
+      options?: { processedBy?: string; note?: string; assignedUserId?: number },
+    ) => {
+      let updatedRequest: RegistrationRequest | undefined;
+
+      setRequests((prev) =>
+        prev.map((request) => {
+          if (request.id !== id) {
+            return request;
+          }
+
+          const next: RegistrationRequest = {
+            ...request,
+            status,
+            processedBy: options?.processedBy ?? request.processedBy,
+            decisionNote: options?.note?.trim() ? options.note.trim() : undefined,
+            assignedUserId: options?.assignedUserId ?? request.assignedUserId,
+          };
+
+          if (status === 'pending') {
+            next.processedAt = undefined;
+            next.processedBy = undefined;
+            next.decisionNote = undefined;
+            next.assignedUserId = undefined;
+          } else {
+            next.processedAt = new Date().toISOString();
+          }
+
+          updatedRequest = next;
+          return next;
+        }),
+      );
+
+      return updatedRequest;
+    },
+    [],
+  );
+
+  const getRequestById = useCallback(
+    (id: string) => requests.find((request) => request.id === id),
+    [requests],
+  );
+
+  const value = useMemo(
+    () => {
+      const pendingRequests = requests.filter((request) => request.status === 'pending');
+      const approvedRequests = requests.filter((request) => request.status === 'approved');
+      const rejectedRequests = requests.filter((request) => request.status === 'rejected');
+
+      return {
+        requests,
+        pendingRequests,
+        approvedRequests,
+        rejectedRequests,
+        createRequest,
+        updateRequestStatus,
+        getRequestById,
+      } satisfies RegistrationContextValue;
+    },
+    [createRequest, getRequestById, requests, updateRequestStatus],
+  );
+
+  return <RegistrationContext.Provider value={value}>{children}</RegistrationContext.Provider>;
+};
+
+export const useRegistration = (): RegistrationContextValue => {
+  const context = useContext(RegistrationContext);
+  if (!context) {
+    throw new Error('useRegistration должен использоваться внутри RegistrationProvider');
+  }
+  return context;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -63,4 +63,11 @@
   .accent {
     color: rgb(var(--color-accent));
   }
+
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 import ProtectedRoute from './components/ProtectedRoute';
 import { AuthProvider } from './context/AuthContext';
+import { RegistrationProvider } from './context/RegistrationContext';
 import Approve from './pages/Approve';
 import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
@@ -14,18 +15,20 @@ import './index.css';
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <AuthProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Login />} />
-          <Route element={<ProtectedRoute />}>
-            <Route path="/dashboard" element={<Dashboard />} />
+      <RegistrationProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Login />} />
             <Route path="/register" element={<Register />} />
-            <Route path="/approve" element={<Approve />} />
-            <Route path="/reject" element={<Reject />} />
-          </Route>
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </BrowserRouter>
+            <Route element={<ProtectedRoute />}>
+              <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="/approve" element={<Approve />} />
+              <Route path="/reject" element={<Reject />} />
+            </Route>
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </BrowserRouter>
+      </RegistrationProvider>
     </AuthProvider>
   </React.StrictMode>,
 );

--- a/src/pages/Approve.tsx
+++ b/src/pages/Approve.tsx
@@ -1,3 +1,289 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  AlertCircle,
+  ArrowRight,
+  BadgeCheck,
+  ClipboardList,
+  Clock4,
+  Loader2,
+  ShieldCheck,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import PortalHeader from '../components/PortalHeader';
+import { useRegistration } from '../context/RegistrationContext';
+import { useAuth, AuthError } from '../context/AuthContext';
+
+const roleDescriptions: Record<string, string> = {
+  reception: 'Администратор ресепшена',
+  doctor: 'Врач',
+  assistant: 'Ассистент врача',
+  admin: 'Управляющий клиники',
+};
+
+const formatDateTime = (value: string) =>
+  new Intl.DateTimeFormat('ru-RU', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+
+const generatePassword = (length = 10) => {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#';
+  let password = '';
+  for (let index = 0; index < length; index += 1) {
+    const randomIndex = Math.floor(Math.random() * alphabet.length);
+    password += alphabet[randomIndex];
+  }
+  return password;
+};
+
 export default function Approve() {
-  return <h1 className="text-3xl p-10">Approve works!</h1>;
+  const { pendingRequests, approvedRequests, updateRequestStatus } = useRegistration();
+  const { createUser, currentUser } = useAuth();
+
+  const sortedPending = useMemo(
+    () => [...pendingRequests].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()),
+    [pendingRequests],
+  );
+
+  const [selectedId, setSelectedId] = useState<string | null>(sortedPending[0]?.id ?? null);
+  const [processing, setProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [issuedCredentials, setIssuedCredentials] = useState<{
+    email: string;
+    password: string;
+    name: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!selectedId && sortedPending[0]) {
+      setSelectedId(sortedPending[0].id);
+      return;
+    }
+
+    if (selectedId && !sortedPending.some((request) => request.id === selectedId)) {
+      setSelectedId(sortedPending[0]?.id ?? null);
+    }
+  }, [selectedId, sortedPending]);
+
+  const selectedRequest = sortedPending.find((request) => request.id === selectedId) ?? null;
+
+  const recentApprovals = useMemo(() => {
+    const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    return approvedRequests.filter((request) => {
+      if (!request.processedAt) {
+        return false;
+      }
+      return new Date(request.processedAt).getTime() >= weekAgo;
+    });
+  }, [approvedRequests]);
+
+  const handleApprove = async () => {
+    if (!selectedRequest) {
+      return;
+    }
+
+    setProcessing(true);
+    setError(null);
+    setIssuedCredentials(null);
+
+    try {
+      const password = generatePassword();
+      const createdUser = await createUser({
+        email: selectedRequest.email,
+        role: selectedRequest.role,
+        password,
+        name: selectedRequest.fullName,
+        requirePasswordSetup: false,
+      });
+
+      updateRequestStatus(selectedRequest.id, 'approved', {
+        processedBy: currentUser?.email,
+        note: 'Создана учетная запись в портале',
+        assignedUserId: createdUser.id,
+      });
+
+      setIssuedCredentials({
+        email: selectedRequest.email,
+        password,
+        name: selectedRequest.fullName,
+      });
+    } catch (err) {
+      if (err instanceof AuthError) {
+        if (err.code === 'user-already-exists') {
+          setError('Пользователь с таким e-mail уже существует. Проверьте журнал отказов или свяжитесь с сотрудником.');
+        } else {
+          setError(err.message);
+        }
+      } else {
+        setError('Не удалось выдать доступ. Попробуйте позже.');
+      }
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-page text-page">
+      <PortalHeader
+        title="Управление заявками"
+        subtitle="Проверяйте запросы сотрудников и выдавайте доступ в пару кликов"
+      />
+
+      <main className="mx-auto max-w-6xl space-y-8 px-4 py-10">
+        <section className="grid gap-4 sm:grid-cols-3">
+          <article className="rounded-2xl border border-page bg-card p-5 shadow-sm">
+            <div className="flex items-center gap-3">
+              <Clock4 className="h-5 w-5 text-orange-500" />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-page/60">Ожидают рассмотрения</p>
+                <p className="text-2xl font-semibold text-page">{pendingRequests.length}</p>
+              </div>
+            </div>
+          </article>
+          <article className="rounded-2xl border border-page bg-card p-5 shadow-sm">
+            <div className="flex items-center gap-3">
+              <ShieldCheck className="h-5 w-5 text-emerald-500" />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-page/60">Одобрено за 7 дней</p>
+                <p className="text-2xl font-semibold text-page">{recentApprovals.length}</p>
+              </div>
+            </div>
+          </article>
+          <article className="rounded-2xl border border-page bg-card p-5 shadow-sm">
+            <div className="flex items-center gap-3">
+              <ClipboardList className="h-5 w-5 text-sky-500" />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-page/60">Всего обработано</p>
+                <p className="text-2xl font-semibold text-page">{approvedRequests.length}</p>
+              </div>
+            </div>
+          </article>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[2fr_3fr]">
+          <aside className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-page">Заявки</h2>
+              <span className="text-xs text-page/60">{sortedPending.length} активных</span>
+            </div>
+
+            <div className="space-y-3">
+              {sortedPending.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-page/70 bg-card/50 p-6 text-center text-sm text-page/60">
+                  Все заявки обработаны. Новые появятся здесь автоматически.
+                </div>
+              ) : (
+                sortedPending.map((request) => {
+                  const isActive = request.id === selectedId;
+                  return (
+                    <button
+                      type="button"
+                      key={request.id}
+                      onClick={() => setSelectedId(request.id)}
+                      className={`w-full rounded-2xl border px-4 py-3 text-left shadow-sm transition ${
+                        isActive
+                          ? 'border-orange-400 bg-orange-50 text-page'
+                          : 'border-page bg-card text-page hover:border-orange-200 hover:bg-orange-50/60'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between text-sm font-semibold">
+                        <span>{request.fullName}</span>
+                        <span className="text-xs text-page/60">{formatDateTime(request.createdAt)}</span>
+                      </div>
+                      <p className="text-xs text-page/60">
+                        {roleDescriptions[request.role] ?? request.role}
+                      </p>
+                      {request.note ? (
+                        <p className="mt-2 text-xs text-page/70 line-clamp-2">{request.note}</p>
+                      ) : null}
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </aside>
+
+          <div className="space-y-4">
+            {selectedRequest ? (
+              <div className="space-y-4 rounded-2xl border border-page bg-card p-6 shadow-lg">
+                <header className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 className="text-xl font-semibold text-page">{selectedRequest.fullName}</h2>
+                    <p className="text-sm text-page/60">{selectedRequest.email}</p>
+                  </div>
+                  <span className="rounded-full bg-orange-100 px-3 py-1 text-xs font-semibold text-orange-600">
+                    {roleDescriptions[selectedRequest.role] ?? selectedRequest.role}
+                  </span>
+                </header>
+
+                <dl className="grid gap-3 text-sm text-page/80 sm:grid-cols-2">
+                  <div>
+                    <dt className="text-xs uppercase text-page/50">Получено</dt>
+                    <dd>{formatDateTime(selectedRequest.createdAt)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase text-page/50">Инициатор</dt>
+                    <dd>{selectedRequest.note ? 'Оставлен комментарий' : 'Комментарий не указан'}</dd>
+                  </div>
+                </dl>
+
+                {selectedRequest.note ? (
+                  <div className="rounded-xl border border-page bg-page/30 p-4 text-sm text-page/80">
+                    <p className="font-semibold text-page">Комментарий заявителя</p>
+                    <p className="mt-2 whitespace-pre-line">{selectedRequest.note}</p>
+                  </div>
+                ) : null}
+
+                {issuedCredentials ? (
+                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+                    <p className="flex items-center gap-2 font-semibold">
+                      <BadgeCheck className="h-4 w-4" /> Доступ выдан
+                    </p>
+                    <p className="mt-2">Передайте сотруднику временный пароль:</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-3 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-emerald-700">
+                      <span>{issuedCredentials.email}</span>
+                      <span className="rounded bg-emerald-600 px-2 py-1 text-white">{issuedCredentials.password}</span>
+                    </div>
+                    <p className="mt-2 text-xs text-emerald-700/80">
+                      В целях безопасности пароль не сохраняется в системе. Смените его при первом входе.
+                    </p>
+                  </div>
+                ) : null}
+
+                {error ? (
+                  <div className="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+                    <AlertCircle className="mt-0.5 h-4 w-4" />
+                    <p>{error}</p>
+                  </div>
+                ) : null}
+
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <button
+                    type="button"
+                    onClick={handleApprove}
+                    disabled={processing}
+                    className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-orange-500 to-yellow-500 px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:from-orange-600 hover:to-yellow-600 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {processing ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                    {processing ? 'Выдаём доступ...' : 'Одобрить и создать аккаунт'}
+                  </button>
+                  <Link
+                    to={`/reject?request=${selectedRequest.id}`}
+                    className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-page px-4 py-3 text-sm font-semibold text-page transition hover:border-red-300 hover:bg-red-50"
+                  >
+                    Отклонить заявку <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-page/70 bg-card/50 p-10 text-center text-sm text-page/60">
+                Выберите заявку из списка, чтобы просмотреть детали и принять решение.
+              </div>
+            )}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { CalendarDays, CheckCircle2, Moon, PhoneCall, Sun, Users } from 'lucide-react';
+import { CalendarDays, CheckCircle2, PhoneCall, Users } from 'lucide-react';
 
 import DoctorConfirmationPanel from '../components/DoctorConfirmationPanel';
 import ScheduleTable from '../components/ScheduleTable';
 import VoiceAssistantPanel from '../components/VoiceAssistantPanel';
 import CalendarView from '../components/CalendarView';
 import { ScheduleProvider, useSchedule } from '../context/ScheduleContext';
-import { useDark } from '../hooks/useDark';
+import PortalHeader from '../components/PortalHeader';
 import { formatDateKey } from '../utils/date';
 
 export default function Dashboard() {
@@ -18,7 +18,6 @@ export default function Dashboard() {
 }
 
 function DashboardContent() {
-  const [dark, toggleDark] = useDark();
   const { appointments, callTasks, doctors } = useSchedule();
 
   const todayKey = formatDateKey(new Date());
@@ -57,18 +56,10 @@ function DashboardContent() {
 
   return (
     <div className="min-h-screen bg-page text-page">
-      <header className="sticky top-0 z-10 border-b border-page bg-card/80 backdrop-blur-lg shadow-sm">
-        <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-          <h1 className="text-xl font-bold">Клиника доктора Денисенко</h1>
-          <button
-            onClick={toggleDark}
-            className="rounded-full border border-page bg-card p-2"
-            title="Переключить тему"
-          >
-            {dark ? <Moon className="accent h-5 w-5" /> : <Sun className="accent h-5 w-5" />}
-          </button>
-        </div>
-      </header>
+      <PortalHeader
+        title="Клиника доктора Денисенко"
+        subtitle="Управление расписанием, персоналом и коммуникациями"
+      />
 
       <main className="mx-auto max-w-7xl space-y-8 px-4 py-10">
         <div className="rounded-2xl bg-gradient-to-r from-orange-400 to-yellow-400 p-8 text-white shadow-xl">

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,7 +1,187 @@
+import React, { useMemo, useState } from 'react';
+import { CheckCircle2, Loader2, Mail, UserPlus } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { useRegistration, RegistrationRole } from '../context/RegistrationContext';
+import { useAuth } from '../context/AuthContext';
+
+interface FormState {
+  fullName: string;
+  email: string;
+  role: RegistrationRole;
+  note: string;
+}
+
+const defaultState: FormState = {
+  fullName: '',
+  email: '',
+  role: 'reception',
+  note: '',
+};
+
+const roleLabels: Record<RegistrationRole, string> = {
+  reception: 'Администратор ресепшена',
+  doctor: 'Врач',
+  assistant: 'Ассистент врача',
+  admin: 'Управляющий клиники',
+};
+
 export default function Register() {
+  const { createRequest, pendingRequests } = useRegistration();
+  const { users } = useAuth();
+
+  const [form, setForm] = useState<FormState>(defaultState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const existingUsersEmails = useMemo(
+    () => new Set(users.map((user) => user.email.toLowerCase())),
+    [users],
+  );
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    const normalizedEmail = form.email.trim().toLowerCase();
+
+    if (existingUsersEmails.has(normalizedEmail)) {
+      setError('Указанный e-mail уже зарегистрирован в системе. Обратитесь к администратору.');
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const request = createRequest({
+        fullName: form.fullName,
+        email: form.email,
+        role: form.role,
+        note: form.note,
+      });
+
+      setForm(defaultState);
+      setSuccessMessage(
+        `Заявка №${request.id.slice(-6)} отправлена. Мы свяжемся по адресу ${request.email}.`,
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Не удалось отправить заявку. Попробуйте ещё раз.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <div className="min-h-screen flex items-center justify-center p-10 bg-page text-page">
-      <h1 className="text-4xl font-bold">Register page works!</h1>
+    <div className="min-h-screen bg-page text-page">
+      <div className="mx-auto flex min-h-screen max-w-5xl flex-col justify-center gap-10 px-4 py-12 md:flex-row md:items-center">
+        <div className="space-y-6 md:w-1/2">
+          <Link to="/" className="text-sm font-medium text-page/70 transition hover:text-page">
+            ← Вернуться ко входу
+          </Link>
+          <h1 className="text-3xl font-bold">Запрос доступа к порталу клиники</h1>
+          <p className="text-sm text-page/70">
+            Заполните форму, чтобы отправить заявку на подключение к административному порталу. После проверки
+            заявки мы пришлём инструкции на указанный e-mail.
+          </p>
+          <div className="rounded-2xl border border-dashed border-page/70 bg-card/50 p-6">
+            <h2 className="mb-2 flex items-center gap-2 text-lg font-semibold">
+              <UserPlus className="h-5 w-5 text-orange-500" /> Что подготовить?
+            </h2>
+            <ul className="list-disc space-y-2 pl-6 text-sm text-page/70">
+              <li>E-mail, к которому у вас есть постоянный доступ.</li>
+              <li>ФИО в соответствии с кадровыми документами.</li>
+              <li>Комментарий для службы безопасности при необходимости.</li>
+            </ul>
+          </div>
+
+          {pendingRequests.length ? (
+            <p className="text-xs text-page/60">
+              В очереди на рассмотрение: {pendingRequests.length}{' '}
+              {pendingRequests.length === 1 ? 'заявка' : pendingRequests.length < 5 ? 'заявки' : 'заявок'}.
+            </p>
+          ) : null}
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="md:w-1/2"
+        >
+          <div className="space-y-4 rounded-2xl border border-page bg-card p-6 shadow-xl">
+            <h2 className="text-xl font-semibold">Форма запроса</h2>
+
+            <label className="block text-sm font-medium text-page">
+              Полное имя
+              <input
+                required
+                value={form.fullName}
+                onChange={(event) => setForm((prev) => ({ ...prev, fullName: event.target.value }))}
+                placeholder="Например, Анастасия Денисенко"
+                className="mt-1 w-full rounded-lg border border-page bg-card px-4 py-3 text-page shadow-sm focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200"
+              />
+            </label>
+
+            <label className="block text-sm font-medium text-page">
+              Рабочий e-mail
+              <input
+                required
+                type="email"
+                value={form.email}
+                onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                placeholder="name@clinic.ru"
+                className="mt-1 w-full rounded-lg border border-page bg-card px-4 py-3 text-page shadow-sm focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200"
+              />
+            </label>
+
+            <label className="block text-sm font-medium text-page">
+              Роль в клинике
+              <select
+                value={form.role}
+                onChange={(event) => setForm((prev) => ({ ...prev, role: event.target.value as RegistrationRole }))}
+                className="mt-1 w-full rounded-lg border border-page bg-card px-4 py-3 text-page shadow-sm focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200"
+              >
+                {Object.entries(roleLabels).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block text-sm font-medium text-page">
+              Дополнительная информация
+              <textarea
+                value={form.note}
+                onChange={(event) => setForm((prev) => ({ ...prev, note: event.target.value }))}
+                placeholder="Опишите задачи или укажите ФИО наставника"
+                rows={4}
+                className="mt-1 w-full rounded-lg border border-page bg-card px-4 py-3 text-sm text-page shadow-sm focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200"
+              />
+            </label>
+
+            {error ? <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p> : null}
+            {successMessage ? (
+              <p className="flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-600">
+                <CheckCircle2 className="h-4 w-4" /> {successMessage}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-orange-500 to-yellow-500 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:from-orange-600 hover:to-yellow-600 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Mail className="h-4 w-4" />}
+              {isSubmitting ? 'Отправляем заявку...' : 'Отправить заявку'}
+            </button>
+
+            <p className="text-xs text-page/60">
+              Нажимая кнопку, вы подтверждаете согласие на обработку персональных данных в соответствии с политикой клиники.
+            </p>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/src/pages/Reject.tsx
+++ b/src/pages/Reject.tsx
@@ -1,3 +1,216 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, ArrowLeft, History, RefreshCcw, ThumbsDown } from 'lucide-react';
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+
+import PortalHeader from '../components/PortalHeader';
+import { useRegistration } from '../context/RegistrationContext';
+import { useAuth } from '../context/AuthContext';
+
+const formatDateTime = (value: string) =>
+  new Intl.DateTimeFormat('ru-RU', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+
 export default function Reject() {
-  return <h1 className="text-3xl p-10">Reject works!</h1>;
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const location = useLocation() as { state?: { notice?: string } };
+  const { currentUser } = useAuth();
+  const { rejectedRequests, updateRequestStatus, getRequestById } = useRegistration();
+
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+  const [pageNotice, setPageNotice] = useState<string | null>(location.state?.notice ?? null);
+
+  useEffect(() => {
+    if (location.state?.notice) {
+      setPageNotice(location.state.notice);
+      navigate(location.pathname, { replace: true, state: undefined });
+    }
+  }, [location, navigate]);
+
+  const requestId = searchParams.get('request');
+  const targetRequest = requestId ? getRequestById(requestId) ?? null : null;
+
+  const sortedRejected = useMemo(
+    () =>
+      [...rejectedRequests].sort((a, b) => {
+        const aTime = a.processedAt ? new Date(a.processedAt).getTime() : 0;
+        const bTime = b.processedAt ? new Date(b.processedAt).getTime() : 0;
+        return bTime - aTime;
+      }),
+    [rejectedRequests],
+  );
+
+  const handleReject = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!targetRequest) {
+      setError('Заявка не найдена или уже обработана.');
+      return;
+    }
+
+    if (targetRequest.status !== 'pending') {
+      setError('Эта заявка уже обработана.');
+      return;
+    }
+
+    if (!reason.trim()) {
+      setError('Укажите причину отказа, чтобы помочь сотруднику исправить ситуацию.');
+      return;
+    }
+
+    setProcessing(true);
+    setError(null);
+
+    const updated = updateRequestStatus(targetRequest.id, 'rejected', {
+      processedBy: currentUser?.email,
+      note: reason.trim(),
+    });
+
+    setProcessing(false);
+
+    if (!updated) {
+      setError('Не удалось обновить статус заявки. Попробуйте позже.');
+      return;
+    }
+
+    setReason('');
+    navigate('/reject', {
+      replace: true,
+      state: {
+        notice: `Заявка ${updated.fullName} отклонена. Информация отправлена ответственному лицу.`,
+      },
+    });
+  };
+
+  const handleRestore = (id: string) => {
+    updateRequestStatus(id, 'pending');
+    setPageNotice('Заявка возвращена в работу. Она снова появится в списке на одобрение.');
+  };
+
+  return (
+    <div className="min-h-screen bg-page text-page">
+      <PortalHeader
+        title="Журнал отказов"
+        subtitle="Фиксируйте причины отказов и возвращайте заявки на повторное рассмотрение"
+      />
+
+      <main className="mx-auto max-w-6xl space-y-8 px-4 py-10">
+        {pageNotice ? (
+          <div className="flex items-start gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+            <History className="mt-0.5 h-4 w-4" />
+            <p>{pageNotice}</p>
+          </div>
+        ) : null}
+
+        {targetRequest ? (
+          <section className="rounded-2xl border border-page bg-card p-6 shadow-lg">
+            <header className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold text-page">Отклонить заявку</h2>
+                <p className="text-sm text-page/60">
+                  {targetRequest.fullName} · {targetRequest.email}
+                </p>
+              </div>
+              <Link
+                to="/approve"
+                className="flex items-center gap-2 rounded-full border border-page px-3 py-1 text-xs font-semibold text-page transition hover:border-page/70 hover:bg-page/20"
+              >
+                <ArrowLeft className="h-3 w-3" /> К списку заявок
+              </Link>
+            </header>
+
+            {targetRequest.status !== 'pending' ? (
+              <p className="mt-4 rounded-xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700">
+                Эта заявка уже была обработана. Проверьте журнал ниже или выберите другую заявку.
+              </p>
+            ) : (
+              <form onSubmit={handleReject} className="mt-6 space-y-4">
+                <label className="block text-sm font-medium text-page">
+                  Причина отказа
+                  <textarea
+                    required
+                    value={reason}
+                    onChange={(event) => setReason(event.target.value)}
+                    rows={5}
+                    placeholder="Опишите, что нужно исправить или предоставить сотруднику"
+                    className="mt-1 w-full rounded-lg border border-page bg-card px-4 py-3 text-sm text-page shadow-sm focus:border-red-400 focus:outline-none focus:ring-2 focus:ring-red-200"
+                  />
+                </label>
+
+                {error ? (
+                  <p className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+                    <AlertCircle className="h-4 w-4" /> {error}
+                  </p>
+                ) : null}
+
+                <button
+                  type="submit"
+                  disabled={processing}
+                  className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-red-500 to-rose-500 px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:from-red-600 hover:to-rose-600 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <ThumbsDown className="h-4 w-4" />
+                  {processing ? 'Фиксируем решение...' : 'Отклонить заявку'}
+                </button>
+              </form>
+            )}
+          </section>
+        ) : null}
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-page">История отказов</h2>
+            <span className="text-xs text-page/60">{sortedRejected.length} записей</span>
+          </div>
+
+          {sortedRejected.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-page/70 bg-card/50 p-10 text-center text-sm text-page/60">
+              Пока нет отклонённых заявок. Все решения будут отображаться здесь.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {sortedRejected.map((request) => (
+                <article
+                  key={request.id}
+                  className="rounded-2xl border border-page bg-card p-5 shadow-sm"
+                >
+                  <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 className="text-base font-semibold text-page">{request.fullName}</h3>
+                      <p className="text-xs text-page/60">{request.email}</p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-page/60">
+                      <span className="rounded-full bg-red-100 px-3 py-1 font-semibold text-red-600">Отклонено</span>
+                      {request.processedAt ? <span>{formatDateTime(request.processedAt)}</span> : null}
+                      {request.processedBy ? <span>Ответственный: {request.processedBy}</span> : null}
+                    </div>
+                  </header>
+
+                  {request.decisionNote ? (
+                    <p className="mt-3 rounded-xl border border-page bg-page/30 p-4 text-sm text-page/80 whitespace-pre-line">
+                      {request.decisionNote}
+                    </p>
+                  ) : null}
+
+                  <div className="mt-4 flex flex-wrap items-center gap-3">
+                    <span className="text-xs uppercase tracking-wide text-page/50">Действия</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRestore(request.id)}
+                      className="inline-flex items-center gap-2 rounded-full border border-page px-3 py-1 text-xs font-semibold text-page transition hover:border-orange-300 hover:bg-orange-50"
+                    >
+                      <RefreshCcw className="h-3 w-3" /> Вернуть в работу
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
 }

--- a/src/services/authDb.ts
+++ b/src/services/authDb.ts
@@ -6,6 +6,7 @@ export interface AuthUser {
   passwordHash: string;
   role: string;
   needsPasswordSetup: boolean;
+  name?: string;
 }
 
 class AuthDatabase extends Dexie {
@@ -33,6 +34,7 @@ const initializeAuthDb = (async () => {
       passwordHash: '',
       role: 'admin',
       needsPasswordSetup: true,
+      name: 'Главный администратор',
     });
   }
 })();


### PR DESCRIPTION
## Summary
- add a registration context with persistence and extend the auth provider to create provisioned users
- introduce a shared portal header layout and expose the public register route alongside protected admin pages
- replace placeholder register/approve/reject screens with full UI for submitting, approving, and declining staff access requests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce946fb5ac8325ab554df63df1d59f