### PR TITLE
Add Ident connection diagnostics UI

### DIFF
--- a/src/services/identApi.ts
+++ b/src/services/identApi.ts
@@ -1,0 +1,160 @@
+import type { IdentIntegrationSettings } from './integrationModule';
+
+export type IdentConnectionResource = 'doctors' | 'branches' | 'schedule' | 'leads' | 'calls';
+
+export interface IdentConnectionConfig {
+  host: string;
+  port?: string | number;
+  username: string;
+  password: string;
+}
+
+export interface IdentPreviewResult {
+  counts: Partial<Record<IdentConnectionResource, number | null>>;
+  errors: Partial<Record<IdentConnectionResource, string>>;
+}
+
+const DEFAULT_ENDPOINTS: Record<IdentConnectionResource, string> = {
+  doctors: '/api/doctors',
+  branches: '/api/branches',
+  schedule: '/api/schedule',
+  leads: '/api/leads',
+  calls: '/api/calls',
+};
+
+const ensureLeadingSlash = (path: string): string => {
+  if (!path.startsWith('/')) {
+    return `/${path}`;
+  }
+  return path;
+};
+
+const encodeBasicAuth = (username: string, password: string) => {
+  const raw = `${username}:${password}`;
+
+  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+    try {
+      return window.btoa(unescape(encodeURIComponent(raw)));
+    } catch (error) {
+      console.error('Не удалось выполнить base64-encoding через window.btoa', error);
+    }
+  }
+
+  if (typeof globalThis !== 'undefined') {
+    const maybeBuffer = (globalThis as unknown as { Buffer?: typeof Buffer }).Buffer;
+    if (maybeBuffer) {
+      return maybeBuffer.from(raw, 'utf-8').toString('base64');
+    }
+  }
+
+  throw new Error('В окружении недоступны инструменты для base64-encoding.');
+};
+
+export const createIdentConnectionConfig = (
+  settings: Pick<IdentIntegrationSettings, 'host' | 'port' | 'username' | 'password'>,
+): IdentConnectionConfig => ({
+  host: settings.host,
+  port: settings.port,
+  username: settings.username,
+  password: settings.password,
+});
+
+const buildBaseUrl = ({ host, port }: IdentConnectionConfig) => {
+  const trimmedHost = host.trim();
+  const sanitizedHost = trimmedHost.replace(/^https?:\/\//i, '');
+  const trimmedPort = typeof port === 'number' ? String(Math.trunc(port)) : port?.trim?.();
+  const sanitizedPort = trimmedPort ? trimmedPort.replace(/^:/, '') : undefined;
+  if (!sanitizedHost) {
+    throw new Error('Не указан адрес сервера интеграции.');
+  }
+
+  if (sanitizedPort) {
+    return `http://${sanitizedHost}:${sanitizedPort}`;
+  }
+
+  return `http://${sanitizedHost}`;
+};
+
+export async function callIdentApi<T>(
+  config: IdentConnectionConfig,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const baseUrl = buildBaseUrl(config);
+  const url = new URL(ensureLeadingSlash(path), baseUrl);
+
+  const headers = new Headers(init?.headers);
+  headers.set('Authorization', `Basic ${encodeBasicAuth(config.username, config.password)}`);
+  headers.set('Accept', 'application/json');
+
+  const response = await fetch(url.toString(), {
+    ...init,
+    headers,
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(
+      `iDent API вернул ошибку ${response.status}. ${text ? `Ответ сервера: ${text}` : 'Тело ответа пустое.'}`,
+    );
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return (await response.json()) as T;
+  }
+
+  // Попытка разобрать даже без корректного заголовка
+  const fallback = await response.text();
+  try {
+    return JSON.parse(fallback) as T;
+  } catch (error) {
+    throw new Error('Сервер вернул данные в неизвестном формате.');
+  }
+}
+
+const normalizeCount = (data: unknown): number | null => {
+  if (Array.isArray(data)) {
+    return data.length;
+  }
+
+  if (data && typeof data === 'object' && 'items' in (data as Record<string, unknown>)) {
+    const maybeItems = (data as Record<string, unknown>).items;
+    if (Array.isArray(maybeItems)) {
+      return maybeItems.length;
+    }
+  }
+
+  if (data === null || data === undefined) {
+    return 0;
+  }
+
+  return 1;
+};
+
+export async function fetchIdentPreview(
+  config: IdentConnectionConfig,
+  endpoints: Partial<Record<IdentConnectionResource, string>> = {},
+): Promise<IdentPreviewResult> {
+  const counts: IdentPreviewResult['counts'] = {};
+  const errors: IdentPreviewResult['errors'] = {};
+
+  await Promise.all(
+    (Object.entries({ ...DEFAULT_ENDPOINTS, ...endpoints }) as Array<[
+      IdentConnectionResource,
+      string,
+    ]>).map(async ([resource, path]) => {
+      try {
+        const data = await callIdentApi<unknown>(config, path);
+        counts[resource] = normalizeCount(data);
+      } catch (error) {
+        console.error(`Ошибка загрузки ресурса ${resource} из iDent`, error);
+        errors[resource] =
+          error instanceof Error ? error.message : 'Неизвестная ошибка при обращении к API iDent';
+      }
+    }),
+  );
+
+  return { counts, errors };
+}

--- a/src/services/integrationModule.ts
+++ b/src/services/integrationModule.ts
@@ -23,6 +23,10 @@ export interface TelegramIntegrationSettings {
 export type IdentAutoSyncInterval = 'manual' | 'hourly' | 'daily';
 
 export interface IdentIntegrationSettings {
+  host: string;
+  port: string;
+  username: string;
+  password: string;
   apiKey: string;
   workspace: string;
   clinicId: string;
@@ -55,6 +59,10 @@ const defaultState: IntegrationSettingsState = {
     lastSync: undefined,
   },
   ident: {
+    host: '',
+    port: '',
+    username: '',
+    password: '',
     apiKey: '',
     workspace: '',
     clinicId: '',
@@ -123,6 +131,12 @@ const loadState = (): IntegrationSettingsState => {
       ident: {
         ...defaultState.ident,
         ...(parsed.ident ?? {}),
+        host: typeof parsed.ident?.host === 'string' ? parsed.ident.host : defaultState.ident.host,
+        port: typeof parsed.ident?.port === 'string' ? parsed.ident.port : defaultState.ident.port,
+        username:
+          typeof parsed.ident?.username === 'string' ? parsed.ident.username : defaultState.ident.username,
+        password:
+          typeof parsed.ident?.password === 'string' ? parsed.ident.password : defaultState.ident.password,
         branchFilters: Array.isArray(parsed.ident?.branchFilters)
           ? parsed.ident!.branchFilters!.map((value) => String(value).trim()).filter(Boolean)
           : [...defaultState.ident.branchFilters],
@@ -376,6 +390,10 @@ export const fetchIdentSettings = async (): Promise<IdentIntegrationSettings> =>
 };
 
 export interface UpdateIdentSettingsPayload {
+  host?: string;
+  port?: string | number;
+  username?: string;
+  password?: string;
   apiKey?: string;
   workspace?: string;
   clinicId?: string;
@@ -396,6 +414,23 @@ export const updateIdentSettings = async (
 ): Promise<IdentIntegrationSettings> => {
   const next = updateState((state) => {
     const ident = { ...state.ident };
+
+    if (typeof updates.host === 'string') {
+      ident.host = updates.host.trim();
+    }
+
+    if (typeof updates.port === 'string' || typeof updates.port === 'number') {
+      const portValue = typeof updates.port === 'number' ? String(Math.trunc(updates.port)) : updates.port;
+      ident.port = portValue.trim();
+    }
+
+    if (typeof updates.username === 'string') {
+      ident.username = updates.username.trim();
+    }
+
+    if (typeof updates.password === 'string') {
+      ident.password = updates.password;
+    }
 
     if (typeof updates.apiKey === 'string') {
       ident.apiKey = updates.apiKey.trim();


### PR DESCRIPTION
## Summary
- initialize the Ident form with defaults and add logging helpers so connection attempts capture success and failure messages
- add a dedicated "Проверка соединения" action that validates credentials, queries the API preview, and records outcomes in the log
- surface the running log beside the Ident status card so administrators can review or clear connection attempts

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d996acd6bc83259595318e10a6e340