### PR TITLE
Register ident API blueprint in Flask app

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1,0 +1,17 @@
+from flask import Flask
+
+from portal.routes.ident_api import bp as ident_bp
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+    app.register_blueprint(ident_bp)
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- create a Flask application entrypoint and register the ident API blueprint so the `/api/ident` routes are available

## Testing
- python - <<'PY'
from portal.app import app

with app.test_client() as client:
    response = client.get("/api/ident/status")
    print(response.status_code)
    print(response.json)
PY


------
https://chatgpt.com/codex/tasks/task_e_68d9cea5763483259fbc2155d310ade6