### PR TITLE
Add persistent logging for iDent integration

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -19,6 +19,7 @@ import {
   fetchPortalUsers,
   fetchTelegramSettings,
   fetchUserProfile,
+  appendIdentLog,
   type IdentAutoSyncInterval,
   type IdentIntegrationSettings,
   type IntegrationUserProfile,
@@ -693,6 +694,11 @@ export default function Settings() {
       setIdentSettings(connectedState);
       setIdentForm(connectedState);
       setIdentBanner({ type: 'success', text: 'iDent подключён и данные успешно получены.' });
+      void appendIdentLog({
+        timestamp: new Date().toISOString(),
+        source: `ident:sync:${trimmedHost}${trimmedPort ? `:${trimmedPort}` : ''}`,
+        message: 'Успешное подключение к iDent и синхронизация данных.',
+      });
     } catch (error) {
       setIdentBanner({
         type: 'error',


### PR DESCRIPTION
## Summary
- add persistent IdentLogEntry storage inside the integration module with serialization and retention limits
- expose helpers to read, append, and clear iDent logs
- record iDent API errors and successful sync events in the new log

## Testing
- npm run build *(fails: vite: not found in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d385e9ec83258498ad23a4667f60