### PR TITLE
Support Nextcloud OCS XML in connection check and show user info in UI

### DIFF
--- a/portal/talk.py
+++ b/portal/talk.py
@@ -9,6 +9,7 @@ import ipaddress
 import urllib.error
 import urllib.parse
 import urllib.request
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -23,7 +24,7 @@ RECOMMENDED_PORTAL_CALLBACK_URL = "https://portal.docdenisenko.ru/api/talk/sched
 DEFAULT_BOT_SERVICE_BASE_URL = os.environ.get(
     "BOT_SERVICE_BASE_URL", "http://127.0.0.1:18081"
 ).rstrip("/")
-DEFAULT_NEXTCLOUD_BASE_URL = os.environ.get("NEXTCLOUD_BASE_URL", "http://127.0.0.1:8080").rstrip("/")
+DEFAULT_NEXTCLOUD_BASE_URL = os.environ.get("NEXTCLOUD_BASE_URL", "https://cloud.docdenisenko.ru").rstrip("/")
 DEFAULT_NEXTCLOUD_SERVICE_USER = os.environ.get("NEXTCLOUD_SERVICE_USER", "cloudadmin")
 DEFAULT_NEXTCLOUD_SERVICE_PASSWORD = os.environ.get("NEXTCLOUD_SERVICE_PASSWORD", "")
 DEFAULT_NEXTCLOUD_BOT_SECRET = os.environ.get("NEXTCLOUD_BOT_SECRET", "")
@@ -350,7 +351,7 @@ def _nc_request(
     settings: dict[str, Any],
     method: str = "GET",
     payload: dict[str, Any] | None = None,
-) -> dict[str, Any]:
+) -> Any:
     if not settings.get("nextcloud_base_url"):
         raise RuntimeError("Не настроен Nextcloud Base URL")
     if not settings.get("nextcloud_service_user") or not settings.get("nextcloud_service_password"):
@@ -358,10 +359,7 @@ def _nc_request(
 
     url = f"{settings['nextcloud_base_url']}{path}"
     data = None
-    headers: dict[str, str] = {
-        "Accept": "application/json",
-        "OCS-APIRequest": "true",
-    }
+    headers: dict[str, str] = {"Accept": "application/json, application/xml, text/xml", "OCS-APIRequest": "true"}
 
     if payload is not None:
         headers["Content-Type"] = "application/x-www-form-urlencoded"
@@ -376,6 +374,8 @@ def _nc_request(
 
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
+            status = response.status
+            content_type = response.headers.get("Content-Type", "")
             body = response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8")
@@ -383,14 +383,72 @@ def _nc_request(
     except urllib.error.URLError as exc:
         raise RuntimeError(f"Ошибка подключения к Nextcloud: {exc.reason}") from exc
 
-    decoded = json.loads(body)
-    if "ocs" in decoded and decoded["ocs"].get("meta", {}).get("status") == "failure":
-        message = decoded["ocs"].get("meta", {}).get("message", "Неизвестная ошибка")
-        raise RuntimeError(f"Nextcloud вернул ошибку: {message}")
+    parsed = _parse_ocs_response(body=body, content_type=content_type)
 
-    if "ocs" in decoded:
-        return decoded["ocs"].get("data", {})
-    return decoded
+    if status != 200:
+        raise RuntimeError(f"Nextcloud вернул HTTP {status}")
+
+    if isinstance(parsed, dict) and "ocs" in parsed and isinstance(parsed["ocs"], dict):
+        meta = parsed["ocs"].get("meta")
+        if isinstance(meta, dict):
+            status_value = str(meta.get("status", "")).strip().lower()
+            if status_value in {"failure", "error", "failed"}:
+                message = str(meta.get("message") or "Неизвестная ошибка")
+                raise RuntimeError(f"Nextcloud вернул ошибку: {message}")
+        return parsed["ocs"].get("data", {})
+
+    return parsed
+
+
+def _xml_element_to_dict(element: ET.Element) -> Any:
+    children = list(element)
+    if not children:
+        return (element.text or "").strip()
+
+    grouped: dict[str, list[Any]] = {}
+    for child in children:
+        key = child.tag.split("}")[-1]
+        grouped.setdefault(key, []).append(_xml_element_to_dict(child))
+
+    if set(grouped.keys()) == {"element"}:
+        return grouped["element"]
+
+    result: dict[str, Any] = {}
+    for key, values in grouped.items():
+        result[key] = values[0] if len(values) == 1 else values
+    return result
+
+
+def _parse_ocs_xml(body: str) -> dict[str, Any]:
+    root = ET.fromstring(body)
+    root_tag = root.tag.split("}")[-1]
+    if root_tag != "ocs":
+        return {root_tag: _xml_element_to_dict(root)}
+
+    result: dict[str, Any] = {"ocs": {}}
+    for child in list(root):
+        key = child.tag.split("}")[-1]
+        result["ocs"][key] = _xml_element_to_dict(child)
+    return result
+
+
+def _parse_ocs_response(body: str, content_type: str) -> Any:
+    raw = body.strip()
+    if not raw:
+        return {}
+
+    normalized_content_type = content_type.lower()
+    is_xml = "xml" in normalized_content_type or raw.startswith("<")
+    if is_xml:
+        try:
+            return _parse_ocs_xml(raw)
+        except ET.ParseError as exc:
+            raise RuntimeError(f"Некорректный XML от Nextcloud: {exc}") from exc
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"raw": raw}
 
 
 def _create_room(room_name: str, settings: dict[str, Any]) -> dict[str, Any]:
@@ -674,7 +732,7 @@ def run_connection_check() -> dict[str, Any]:
     callback_bearer = (settings.get("nextcloud_bot_secret") or "").strip()
 
     run_step("nextcloud_base_url", lambda: _http_request(f"{settings['nextcloud_base_url']}/status.php", method="GET"))
-    run_step("nextcloud_credentials", lambda: _nc_request("/ocs/v1.php/cloud/user", settings=settings))
+    run_step("nextcloud_credentials", lambda: _nc_request("/ocs/v2.php/cloud/user", settings=settings))
     run_step("talk_api", lambda: _nc_request("/ocs/v2.php/apps/spreed/api/v4/room", settings=settings))
     run_step("users_list", lambda: _fetch_nextcloud_users(settings))
     run_step("bot_service_base_url", lambda: _http_request(bot_service_base, method="GET"))

--- a/src/pages/DoctorConfirmationSettings.tsx
+++ b/src/pages/DoctorConfirmationSettings.tsx
@@ -23,6 +23,7 @@ import {
 } from '../services/integrationModule';
 
 type Banner = { type: 'success' | 'error'; text: string } | null;
+type NextcloudUserPreview = { displayName: string; userId: string; groups: string[] } | null;
 
 const formatDateTime = (iso?: string) => (iso ? new Date(iso).toLocaleString('ru-RU') : '—');
 
@@ -32,6 +33,7 @@ export default function DoctorConfirmationSettingsPage() {
   const [banner, setBanner] = useState<Banner>(null);
   const [connectionBanner, setConnectionBanner] = useState<Banner>(null);
   const [syncBanner, setSyncBanner] = useState<Banner>(null);
+  const [nextcloudUserPreview, setNextcloudUserPreview] = useState<NextcloudUserPreview>(null);
   const [doctors, setDoctors] = useState<TalkDoctor[]>([]);
   const [syncLogs, setSyncLogs] = useState<Array<{ status: string; message: string; created_at: string }>>([]);
   const [excludeUsersInput, setExcludeUsersInput] = useState('talkbot');
@@ -94,11 +96,27 @@ export default function DoctorConfirmationSettingsPage() {
   const handleConnectionCheck = async () => {
     setIsCheckingConnection(true);
     setConnectionBanner(null);
+    setNextcloudUserPreview(null);
     try {
       const result = await checkNextcloudTalkConnection();
+      const credentialCheck = result.checks.find((item) => item.name === 'nextcloud_credentials');
+      const userDetails = (credentialCheck?.detail && typeof credentialCheck.detail === 'object'
+        ? credentialCheck.detail
+        : {}) as Record<string, unknown>;
+      const groupsRaw = userDetails.groups;
+      const groups = Array.isArray(groupsRaw)
+        ? groupsRaw.map((group) => String(group)).filter(Boolean)
+        : typeof groupsRaw === 'string' && groupsRaw
+          ? [groupsRaw]
+          : [];
+      setNextcloudUserPreview({
+        displayName: String(userDetails['display-name'] ?? userDetails.displayname ?? userDetails.id ?? '—'),
+        userId: String(userDetails.id ?? '—'),
+        groups,
+      });
       setConnectionBanner({
         type: result.ok ? 'success' : 'error',
-        text: result.ok ? 'Проверка соединения успешна.' : 'Проверка соединения завершилась с ошибками.',
+        text: result.ok ? 'Соединение успешно' : 'Проверка соединения завершилась с ошибками.',
       });
       await load();
     } catch (error) {
@@ -155,7 +173,7 @@ export default function DoctorConfirmationSettingsPage() {
           <div className="grid gap-4 lg:grid-cols-2">
             <label className="space-y-1 text-sm">
               <span>Nextcloud Base URL</span>
-              <input type="url" value={form?.nextcloudBaseUrl ?? ''} onChange={(event) => updateField('nextcloudBaseUrl', event.target.value)} className="input-field" placeholder="https://cloud.example.ru" />
+              <input type="url" value={form?.nextcloudBaseUrl ?? ''} onChange={(event) => updateField('nextcloudBaseUrl', event.target.value)} className="input-field" placeholder="https://cloud.docdenisenko.ru" />
             </label>
             <label className="space-y-1 text-sm">
               <span>Webhook/Base URL бота</span>
@@ -199,6 +217,14 @@ export default function DoctorConfirmationSettingsPage() {
             </button>
           </div>
           {connectionBanner ? <p className={`rounded-lg px-3 py-2 text-sm ${connectionBanner.type === 'success' ? 'bg-emerald-500/10 text-emerald-700' : 'bg-red-500/10 text-red-700'}`}>{connectionBanner.text}</p> : null}
+          {nextcloudUserPreview ? (
+            <div className="rounded-lg border border-emerald-300/60 bg-emerald-50/50 px-3 py-2 text-sm">
+              <p className="font-medium">Пользователь Nextcloud</p>
+              <p>display name: {nextcloudUserPreview.displayName || '—'}</p>
+              <p>user id: {nextcloudUserPreview.userId || '—'}</p>
+              <p>groups: {nextcloudUserPreview.groups.length ? nextcloudUserPreview.groups.join(', ') : '—'}</p>
+            </div>
+          ) : null}
         </form>
 
         <section className="space-y-3 rounded-2xl border border-page bg-card p-6 shadow-lg">

--- a/src/services/integrationModule.ts
+++ b/src/services/integrationModule.ts
@@ -117,7 +117,7 @@ const defaultState: IntegrationSettingsState = {
     reminderHoursBefore: 24,
     requireDoctorCommentOnReject: true,
     approvalGraceMinutes: 45,
-    nextcloudBaseUrl: 'http://127.0.0.1:8080',
+    nextcloudBaseUrl: 'https://cloud.docdenisenko.ru',
     nextcloudServiceUser: 'cloudadmin',
     nextcloudServicePassword: '',
     nextcloudBotSecret: '',


### PR DESCRIPTION
### Motivation
- The backend incorrectly treated Nextcloud OCS XML responses as empty (it expected JSON), causing valid connections to be reported as failed.  
- The connection check must use the correct Base URL, include `OCS-APIRequest: true` and Basic Auth, and validate success by HTTP 200 plus OCS `meta.status`.  
- The settings UI should show a clear success message and surface the Nextcloud service user details (display name, user id, groups) after a successful check.  
- Prevent accidental truncation/incorrect default for the Base URL by setting the example/default to the real host (`https://cloud.docdenisenko.ru`).

### Description
- Implemented robust OCS response handling in the backend (`portal/talk.py`) by: parsing XML responses with `xml.etree.ElementTree`, accepting `application/xml`/`text/xml`, and converting OCS XML into Python structures; keeping `OCS-APIRequest: true` and Basic Auth; enforcing HTTP 200 and checking `ocs.meta.status` for failure messages; returning the `ocs.data` payload when present.  
- Switched the credentials check to use `GET /ocs/v2.php/cloud/user` in the connection-check flow (`run_connection_check`).  
- Updated backend default `DEFAULT_NEXTCLOUD_BASE_URL` to `https://cloud.docdenisenko.ru` to match the provided environment and avoid `.r` truncation.  
- Exposed user info in the frontend settings page (`src/pages/DoctorConfirmationSettings.tsx`) by extracting `nextcloud_credentials` check detail and rendering `display name`, `user id`, and `groups` after a check, and changed the success text to `Соединение успешно`.  
- Updated client-side defaults/placeholder in `src/services/integrationModule.ts` and the settings UI to use `https://cloud.docdenisenko.ru` as the example Base URL.

### Testing
- `python -m py_compile portal/talk.py` — succeeded.  
- `npm run -s build` — failed in the container due to missing toolchain (`vite: not found`), so frontend build could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7173942cc83259e98f9b522f16105)