### PR TITLE
Add `/api/nextcloud/test-connection` endpoint and update frontend to call it

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1,6 +1,7 @@
 from flask import Flask
 
 from portal.routes.ident_api import bp as ident_bp
+from portal.routes.nextcloud_api import bp as nextcloud_bp
 from portal.routes.security_api import bp as security_bp
 from portal.routes.talk_api import bp as talk_bp
 
@@ -11,6 +12,7 @@ def create_app() -> Flask:
     app.register_blueprint(ident_bp)
     app.register_blueprint(security_bp)
     app.register_blueprint(talk_bp)
+    app.register_blueprint(nextcloud_bp)
     return app
 
 

--- a/portal/routes/nextcloud_api.py
+++ b/portal/routes/nextcloud_api.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import base64
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+
+from flask import Blueprint, jsonify, request
+
+bp = Blueprint("nextcloud_api", __name__, url_prefix="/api/nextcloud")
+
+
+def _xml_text(parent: ET.Element, path: str) -> str:
+    found = parent.find(path)
+    if found is None or found.text is None:
+        return ""
+    return found.text.strip()
+
+
+@bp.post("/test-connection")
+def test_connection():
+    payload = request.get_json(silent=True) or {}
+    base_url = str(payload.get("baseUrl", "")).strip().rstrip("/")
+    username = str(payload.get("username", "")).strip()
+    password = str(payload.get("password", ""))
+
+    if not base_url or not username or not password:
+        return jsonify({"success": False, "error": "baseUrl, username и password обязательны"}), 400
+
+    endpoint = f"{base_url}/ocs/v2.php/cloud/user"
+    headers = {
+        "Accept": "application/json, text/xml, application/xml;q=0.9, */*;q=0.8",
+        "OCS-APIRequest": "true",
+        "Authorization": "Basic " + base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii"),
+    }
+
+    req = urllib.request.Request(endpoint, headers=headers, method="GET")
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            status = resp.getcode()
+            body = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else str(exc)
+        return jsonify({"success": False, "error": f"Nextcloud HTTP {exc.code}: {detail[:300]}"}), 502
+    except urllib.error.URLError as exc:
+        return jsonify({"success": False, "error": f"Nextcloud недоступен: {exc.reason}"}), 502
+    except Exception as exc:  # noqa: BLE001
+        return jsonify({"success": False, "error": f"Ошибка запроса: {exc}"}), 500
+
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as exc:
+        return jsonify({"success": False, "error": f"Некорректный XML в ответе: {exc}"}), 502
+
+    if root.tag != "ocs":
+        return jsonify({"success": False, "error": "Ответ не является OCS XML"}), 502
+
+    status_text = _xml_text(root, "./meta/status").lower()
+    if status != 200 or status_text != "ok":
+        statuscode = _xml_text(root, "./meta/statuscode")
+        message = _xml_text(root, "./meta/message")
+        return jsonify(
+            {
+                "success": False,
+                "error": f"OCS status={status_text or 'unknown'} statuscode={statuscode or 'unknown'} message={message or 'empty'}",
+            }
+        ), 502
+
+    data = root.find("./data")
+    user_id = _xml_text(data, "./id") if data is not None else username
+    display_name = _xml_text(data, "./display-name") if data is not None else ""
+
+    groups: list[str] = []
+    if data is not None:
+        groups_node = data.find("./groups")
+        if groups_node is not None:
+            groups = [
+                (child.text or "").strip()
+                for child in groups_node.findall("./element")
+                if (child.text or "").strip()
+            ]
+
+    return jsonify(
+        {
+            "success": True,
+            "user": user_id or username,
+            "displayName": display_name,
+            "groups": groups,
+            "rawStatus": status,
+        }
+    )

--- a/src/services/integrationModule.ts
+++ b/src/services/integrationModule.ts
@@ -746,27 +746,55 @@ export const checkNextcloudTalkConnection = async (): Promise<{
   checkedAt: string;
   checks: Array<{ name: string; ok: boolean; detail?: unknown }>;
 }> => {
-  const response = await fetch('/api/talk/connection-check', { method: 'POST' });
+  const settings = await fetchDoctorConfirmationSettings();
+
+  const response = await fetch('/api/nextcloud/test-connection', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      baseUrl: settings.nextcloudBaseUrl,
+      username: settings.nextcloudServiceUser,
+      password: settings.nextcloudServicePassword,
+    }),
+  });
+
   const payload = (await response.json().catch(() => null)) as
-    | { ok?: boolean; checkedAt?: string; checks?: Array<{ name: string; ok: boolean; detail?: unknown }>; error?: string }
+    | { success?: boolean; user?: string; displayName?: string; groups?: string[]; rawStatus?: number; error?: string }
     | null;
+
   if (!payload) {
     throw new Error('Пустой ответ проверки соединения.');
   }
-  if (!response.ok && !payload.ok) {
+
+  if (!response.ok || !payload.success) {
     throw new Error(payload.error ?? 'Проверка соединения не прошла.');
   }
-  const result = {
-    ok: Boolean(payload.ok),
-    checkedAt: payload.checkedAt ?? new Date().toISOString(),
-    checks: payload.checks ?? [],
-  };
+
+  const checkedAt = new Date().toISOString();
+  const checks = [
+    {
+      name: 'nextcloud_credentials',
+      ok: true,
+      detail: {
+        user: payload.user,
+        displayName: payload.displayName,
+        groups: payload.groups ?? [],
+        rawStatus: payload.rawStatus,
+      },
+    },
+  ];
+
   updateState((state) => {
-    state.doctorConfirmation.connected = result.ok;
-    state.doctorConfirmation.lastConnectionCheckAt = result.checkedAt;
-    state.doctorConfirmation.lastConnectionCheckResult = result.checks;
+    state.doctorConfirmation.connected = true;
+    state.doctorConfirmation.lastConnectionCheckAt = checkedAt;
+    state.doctorConfirmation.lastConnectionCheckResult = checks;
   });
-  return result;
+
+  return {
+    ok: true,
+    checkedAt,
+    checks,
+  };
 };
 
 export const syncTalkDoctorsFromNextcloud = async (payload?: {


### PR DESCRIPTION
### Motivation
- The UI reported `404 Not Found` for `/api/nextcloud/test-connection`, indicating a backend/frontend route mismatch that prevents the "Проверить соединение" flow from validating Nextcloud credentials. 
- Provide a dedicated backend contract so the UI can validate Nextcloud credentials by calling `POST /api/nextcloud/test-connection` with `baseUrl`, `username` and `password`.

### Description
- Added a new Flask blueprint `portal/routes/nextcloud_api.py` implementing `POST /api/nextcloud/test-connection` that performs `GET {baseUrl}/ocs/v2.php/cloud/user` with `OCS-APIRequest: true` and Basic Auth, parses OCS XML and returns normalized JSON (`success`, `user`, `displayName`, `groups`, `rawStatus` or `success: false` with `error`).
- Registered the new blueprint in `portal/app.py` so the `/api/nextcloud` routes are exposed by the app.
- Updated the frontend `checkNextcloudTalkConnection` in `src/services/integrationModule.ts` to call `POST /api/nextcloud/test-connection`, send current settings (`nextcloudBaseUrl`, `nextcloudServiceUser`, `nextcloudServicePassword`), and map the response into the existing UI check format (`nextcloud_credentials`).
- Implemented input validation and error handling on the backend to return appropriate HTTP status codes for missing parameters, HTTP/URL errors, XML parse errors, and non-ok OCS responses.

### Testing
- Attempted to instantiate the Flask app and list `app.url_map` to verify registered routes, but the run failed with `ModuleNotFoundError: No module named 'flask'` in the environment (automated check failed). 
- Attempted a frontend build with `npm run build` to validate the changes, but the command failed with `vite: not found` in the environment (automated check failed). 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71c7ecd7883259f73c0f04f2c2833)